### PR TITLE
[codex] Improve plugin version fallback compatibility

### DIFF
--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/API.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/API.kt
@@ -36,6 +36,16 @@ data class EntryIdMap(val modrinth: List<String>, val hangar: List<String>, val 
 
 data class Hash(val sha256: String, val sha512: String)
 
+private const val MAX_PLATFORM_VERSION_PAGE_SIZE = 500
+private const val MAX_PLATFORM_VERSION_PAGES = 20
+
+internal fun nextPlatformVersionsOffset(pagination: Pagination, currentOffset: Int, receivedCount: Int): Int? {
+    if (!pagination.hasMore || receivedCount <= 0) return null
+
+    val nextOffset = pagination.offset + pagination.limit
+    return nextOffset.takeIf { it > currentOffset }
+}
+
 object API {
     private val client = OkHttpClient().newBuilder().build()
     private var authKey: String? = null
@@ -307,22 +317,43 @@ object API {
         return getAllPluginsByPlatformIds(listOf(platformId))?.get(platformId.platform)?.get(platformId.platformId)
     }
 
-    fun getPluginVersions(platformId: PlatformId, limit: Int = 500): Array<Version>? {
-        val response = orpcCall(
-            "/versions/platform/${platformId.platform.name.lowercase()}/${platformId.platformId}",
-            params = mapOf("limit" to limit.toString())
-        )
+    fun getPluginVersions(platformId: PlatformId, limit: Int = MAX_PLATFORM_VERSION_PAGE_SIZE): Array<Version>? {
+        val pageSize = limit.coerceIn(1, MAX_PLATFORM_VERSION_PAGE_SIZE)
+        val versions = mutableListOf<Version>()
+        var offset = 0
+        var pagesFetched = 0
 
-        if (!response.isSuccessful()) {
-            logRequestFailure("Plugin version lookup", response)
-            return null
+        while (pagesFetched < MAX_PLATFORM_VERSION_PAGES) {
+            val response = orpcCall(
+                "/versions/platform/${platformId.platform.name.lowercase()}/${platformId.platformId}",
+                params = mapOf(
+                    "limit" to pageSize.toString(),
+                    "offset" to offset.toString()
+                )
+            )
+
+            if (!response.isSuccessful()) {
+                logRequestFailure("Plugin version lookup", response)
+                return versions.takeIf { it.isNotEmpty() }?.toTypedArray()
+            }
+
+            val page = runCatching {
+                GSON.fromJson(response.body, ORPCPlatformVersionsResponse::class.java)
+            }.onFailure {
+                logParseFailure("Plugin version lookup", it)
+            }.getOrNull() ?: return versions.takeIf { it.isNotEmpty() }?.toTypedArray()
+
+            versions.addAll(page.versions.asList())
+            pagesFetched++
+
+            offset = nextPlatformVersionsOffset(page.pagination, offset, page.versions.size) ?: break
         }
 
-        return runCatching {
-            GSON.fromJson(response.body, ORPCPlatformVersionsResponse::class.java).versions
-        }.onFailure {
-            logParseFailure("Plugin version lookup", it)
-        }.getOrNull()
+        if (pagesFetched >= MAX_PLATFORM_VERSION_PAGES) {
+            PluginPortalBase.plugin.logger.warning("Plugin version lookup stopped after $MAX_PLATFORM_VERSION_PAGES pages for ${platformId.platform} ${platformId.platformId}.")
+        }
+
+        return versions.toTypedArray()
     }
 
     fun getAllPluginsByPlatformIds(platformIds: List<PlatformId>): Map<MarketplacePlatform, Map<String, Plugin?>>? {

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/adapters/PolymartAdapter.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/adapters/PolymartAdapter.kt
@@ -1,16 +1,12 @@
 package gg.flyte.pluginportal.common.adapters
 
-import com.google.gson.JsonObject
-import gg.flyte.pluginportal.common.PluginPortalBase
 import gg.flyte.pluginportal.common.types.LocalPlugin
 import gg.flyte.pluginportal.common.types.enums.MarketplacePlatform
-import gg.flyte.pluginportal.common.util.GSON
 import gg.flyte.pluginportal.common.util.HashType
 import gg.flyte.pluginportal.common.util.download
+import gg.flyte.pluginportal.common.util.getPolymartDownloadUrl
 import java.io.File
-import java.net.HttpURLConnection
 import java.net.URL
-import java.net.URLEncoder
 
 class PolymartAdapter : DownloadAdapter {
     override fun getPriority(): Int = 200
@@ -36,7 +32,7 @@ class PolymartAdapter : DownloadAdapter {
         
         // For free plugins, we can use the direct download URL
         try {
-            val downloadUrl = getPolymartDownloadUrl(polymart.platformId, null, isPremium)
+            val downloadUrl = getPolymartDownloadUrl(polymart.platformId)
                 ?: return DownloadResult(false, error = "Failed to get download URL from Polymart API")
             
             // Download the file
@@ -63,54 +59,4 @@ class PolymartAdapter : DownloadAdapter {
             return DownloadResult(false, error = "Download failed: ${e.message}")
         }
     }
-    
-    
-    private fun getPolymartDownloadUrl(resourceId: String, token: String?, isPremium: Boolean): String? {
-        return try {
-            val url = URL("https://api.polymart.org/v1/getDownloadURL")
-            val connection = url.openConnection() as HttpURLConnection
-            connection.requestMethod = "POST"
-            connection.doOutput = true
-            connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
-            
-            val postData = buildString {
-                append("resource_id=${URLEncoder.encode(resourceId, "UTF-8")}")
-                // Only add token parameter if it's not null and not blank
-                // For free resources, we should NOT send any token parameter at all
-                if (!token.isNullOrBlank()) {
-                    // For premium resources, this must be a valid OAuth token
-                    // obtained through the user authorization flow
-                    append("&token=${URLEncoder.encode(token, "UTF-8")}")
-                }
-            }
-
-            PluginPortalBase.plugin.logger.info(
-                "Requesting Polymart download URL from $url for resource $resourceId (${if (isPremium) "premium" else "free"})"
-            )
-            connection.outputStream.use { it.write(postData.toByteArray()) }
-            
-            val responseCode = connection.responseCode
-            
-            if (responseCode == 200) {
-                val response = connection.inputStream.bufferedReader().use { it.readText() }
-                val json = GSON.fromJson(response, JsonObject::class.java)
-                
-                if (json.getAsJsonObject("response")?.get("success")?.asBoolean == true) {
-                    return json.getAsJsonObject("response")
-                        ?.getAsJsonObject("result")
-                        ?.get("url")?.asString
-                } else {
-                    val error = json.getAsJsonObject("response")?.get("message")?.asString
-                    PluginPortalBase.plugin.logger.warning("Polymart download URL request failed: ${error ?: "unknown error"}")
-                }
-            } else {
-                PluginPortalBase.plugin.logger.warning("Polymart download URL request failed with HTTP $responseCode")
-            }
-            null
-        } catch (e: Exception) {
-            PluginPortalBase.plugin.logger.warning("Polymart download URL request failed: ${e.message ?: e::class.simpleName}")
-            null
-        }
-    }
-    
 }

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/adapters/StandardMarketplaceAdapter.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/adapters/StandardMarketplaceAdapter.kt
@@ -1,11 +1,7 @@
 package gg.flyte.pluginportal.common.adapters
 
-import gg.flyte.pluginportal.common.managers.MarketplacePluginCache
-import gg.flyte.pluginportal.common.types.compatibleVersions
-import gg.flyte.pluginportal.common.types.Plugin
-import gg.flyte.pluginportal.common.types.Version
-import gg.flyte.pluginportal.common.types.PlatformPlugin
-import gg.flyte.pluginportal.common.util.ActionResponseString
+import gg.flyte.pluginportal.common.API
+import gg.flyte.pluginportal.common.types.newestCompatibleVersionWithFallback
 import gg.flyte.pluginportal.common.util.HashType
 import gg.flyte.pluginportal.common.util.currentMinecraftVersion
 import gg.flyte.pluginportal.common.util.currentServerTypePreference
@@ -28,17 +24,18 @@ class StandardMarketplaceAdapter : DownloadAdapter {
             // Search through all platforms for versions matching the release channel
             plugin.platforms.asList()
                 .filter { gg.flyte.pluginportal.common.Config.isDownloadPlatformEnabled(it.platform) }
-                .flatMap { platform -> 
-                    platform.versions
-                        .compatibleVersions(serverTypes, minecraftVersion)
-                        .filter { version -> version.releaseChannel.equals(request.versionFilter, ignoreCase = true) } // TODO: Probably pass this to the endpoint as well
-                        .map { version -> platform to version }
+                .mapNotNull { platform ->
+                    platform.newestCompatibleVersionWithFallback(request.versionFilter, serverTypes, minecraftVersion) {
+                        API.getPluginVersions(platform.platformWithId)?.toList()
+                    }?.let { version -> platform to version }
                 }
                 .firstOrNull() // Get the first (newest) version matching the channel
         } else {
             // Default to latest version from best platform
             plugin.platforms.bestDownloadable?.let { platform ->
-                platform.newestCompatibleVersion(null, serverTypes, minecraftVersion)?.let { version -> platform to version }
+                platform.newestCompatibleVersionWithFallback(null, serverTypes, minecraftVersion) {
+                    API.getPluginVersions(platform.platformWithId)?.toList()
+                }?.let { version -> platform to version }
             }
         }
         

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/adapters/StandardMarketplaceAdapter.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/adapters/StandardMarketplaceAdapter.kt
@@ -1,11 +1,13 @@
 package gg.flyte.pluginportal.common.adapters
 
 import gg.flyte.pluginportal.common.managers.MarketplacePluginCache
+import gg.flyte.pluginportal.common.types.compatibleVersions
 import gg.flyte.pluginportal.common.types.Plugin
 import gg.flyte.pluginportal.common.types.Version
 import gg.flyte.pluginportal.common.types.PlatformPlugin
 import gg.flyte.pluginportal.common.util.ActionResponseString
 import gg.flyte.pluginportal.common.util.HashType
+import gg.flyte.pluginportal.common.util.currentMinecraftVersion
 import gg.flyte.pluginportal.common.util.currentServerTypePreference
 import java.io.File
 
@@ -18,6 +20,8 @@ class StandardMarketplaceAdapter : DownloadAdapter {
     
     override fun download(request: DownloadRequest): DownloadResult {
         val plugin = request.plugin ?: return DownloadResult(false, error = "No plugin provided")
+        val serverTypes = currentServerTypePreference()
+        val minecraftVersion = currentMinecraftVersion()
         
         // Find the right version based on versionFilter (channel)
         val platformVersion = if (request.versionFilter != null) { // TODO: Pass this work onto the endpoint
@@ -26,14 +30,15 @@ class StandardMarketplaceAdapter : DownloadAdapter {
                 .filter { gg.flyte.pluginportal.common.Config.isDownloadPlatformEnabled(it.platform) }
                 .flatMap { platform -> 
                     platform.versions
-                        .filter { version -> version.releaseChannel.equals(request.versionFilter, ignoreCase = true) && version.isCompatibleWith(currentServerTypePreference()) } // TODO: Probably pass this to the endpoint as well
+                        .compatibleVersions(serverTypes, minecraftVersion)
+                        .filter { version -> version.releaseChannel.equals(request.versionFilter, ignoreCase = true) } // TODO: Probably pass this to the endpoint as well
                         .map { version -> platform to version }
                 }
                 .firstOrNull() // Get the first (newest) version matching the channel
         } else {
             // Default to latest version from best platform
             plugin.platforms.bestDownloadable?.let { platform ->
-                platform.newestCompatibleVersion(null, currentServerTypePreference())?.let { version -> platform to version }
+                platform.newestCompatibleVersion(null, serverTypes, minecraftVersion)?.let { version -> platform to version }
             }
         }
         

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/InstallSubCommand.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/InstallSubCommand.kt
@@ -12,12 +12,12 @@ import gg.flyte.pluginportal.common.commands.lamp.MarketplacePluginSuggestionPro
 import gg.flyte.pluginportal.common.commands.lamp.ReleaseChannelSuggestionProvider
 import gg.flyte.pluginportal.common.managers.MarketplacePluginCache
 import gg.flyte.pluginportal.common.types.ExactVersionSelection
-import gg.flyte.pluginportal.common.types.exactCompatibleVersion
-import gg.flyte.pluginportal.common.types.newestCompatibleVersion
+import gg.flyte.pluginportal.common.types.exactCompatibleVersionWithFallback
 import gg.flyte.pluginportal.common.types.newestCompatibleVersionWithFallback
 import gg.flyte.pluginportal.common.types.enums.MarketplacePlatform
 import gg.flyte.pluginportal.common.util.SharedComponents
 import gg.flyte.pluginportal.common.util.async
+import gg.flyte.pluginportal.common.util.currentMinecraftVersion
 import gg.flyte.pluginportal.common.util.currentServerTypePreference
 import gg.flyte.pluginportal.common.util.download
 import net.kyori.adventure.audience.Audience
@@ -71,16 +71,12 @@ class InstallSubCommand {
                     }
 
                     val serverTypes = currentServerTypePreference()
+                    val minecraftVersion = currentMinecraftVersion()
                     val exactVersionNumber = versionNumber?.takeIf { it.isNotBlank() }
                     val targetVersion = if (exactVersionNumber != null) {
-                        val selection = targetPlatform.exactCompatibleVersion(exactVersionNumber, targetChannel, serverTypes)
-                            .let { initial ->
-                                if (initial != ExactVersionSelection.NotFound) initial
-                                else API.getPluginVersions(targetPlatform.platformWithId)
-                                    ?.toList()
-                                    ?.exactCompatibleVersion(exactVersionNumber, targetChannel, serverTypes)
-                                    ?: initial
-                            }
+                        val selection = targetPlatform.exactCompatibleVersionWithFallback(exactVersionNumber, targetChannel, serverTypes, minecraftVersion) {
+                            API.getPluginVersions(targetPlatform.platformWithId)?.toList()
+                        }
 
                         when (selection) {
                             is ExactVersionSelection.Found -> selection.version
@@ -94,7 +90,7 @@ class InstallSubCommand {
                             }
                         }
                     } else {
-                        targetPlatform.newestCompatibleVersionWithFallback(targetChannel, serverTypes) {
+                        targetPlatform.newestCompatibleVersionWithFallback(targetChannel, serverTypes, minecraftVersion) {
                             API.getPluginVersions(targetPlatform.platformWithId)?.toList()
                         }
                     }

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/InstallSubCommand.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/InstallSubCommand.kt
@@ -13,6 +13,8 @@ import gg.flyte.pluginportal.common.commands.lamp.ReleaseChannelSuggestionProvid
 import gg.flyte.pluginportal.common.managers.MarketplacePluginCache
 import gg.flyte.pluginportal.common.types.ExactVersionSelection
 import gg.flyte.pluginportal.common.types.exactCompatibleVersion
+import gg.flyte.pluginportal.common.types.newestCompatibleVersion
+import gg.flyte.pluginportal.common.types.newestCompatibleVersionWithFallback
 import gg.flyte.pluginportal.common.types.enums.MarketplacePlatform
 import gg.flyte.pluginportal.common.util.SharedComponents
 import gg.flyte.pluginportal.common.util.async
@@ -68,14 +70,15 @@ class InstallSubCommand {
                         return@async
                     }
 
+                    val serverTypes = currentServerTypePreference()
                     val exactVersionNumber = versionNumber?.takeIf { it.isNotBlank() }
                     val targetVersion = if (exactVersionNumber != null) {
-                        val selection = targetPlatform.exactCompatibleVersion(exactVersionNumber, targetChannel, currentServerTypePreference())
+                        val selection = targetPlatform.exactCompatibleVersion(exactVersionNumber, targetChannel, serverTypes)
                             .let { initial ->
                                 if (initial != ExactVersionSelection.NotFound) initial
                                 else API.getPluginVersions(targetPlatform.platformWithId)
                                     ?.toList()
-                                    ?.exactCompatibleVersion(exactVersionNumber, targetChannel, currentServerTypePreference())
+                                    ?.exactCompatibleVersion(exactVersionNumber, targetChannel, serverTypes)
                                     ?: initial
                             }
 
@@ -91,7 +94,9 @@ class InstallSubCommand {
                             }
                         }
                     } else {
-                        targetPlatform.newestCompatibleVersion(targetChannel, currentServerTypePreference())
+                        targetPlatform.newestCompatibleVersionWithFallback(targetChannel, serverTypes) {
+                            API.getPluginVersions(targetPlatform.platformWithId)?.toList()
+                        }
                     }
 
                     if (targetVersion == null) {

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/PlatformSubCommand.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/PlatformSubCommand.kt
@@ -1,5 +1,6 @@
 package gg.flyte.pluginportal.common.commands
 
+import gg.flyte.pluginportal.common.API
 import gg.flyte.pluginportal.common.Config
 import gg.flyte.pluginportal.common.chat.*
 import gg.flyte.pluginportal.common.commands.lamp.EnabledCommand
@@ -9,6 +10,7 @@ import gg.flyte.pluginportal.common.managers.LocalPluginCache
 import gg.flyte.pluginportal.common.managers.MarketplacePluginCache
 import gg.flyte.pluginportal.common.notifications.DiscordWebhookNotifier
 import gg.flyte.pluginportal.common.types.LocalPlugin
+import gg.flyte.pluginportal.common.types.newestCompatibleVersionWithFallback
 import gg.flyte.pluginportal.common.types.enums.MarketplacePlatform
 import gg.flyte.pluginportal.common.util.async
 import gg.flyte.pluginportal.common.util.currentServerTypePreference
@@ -68,7 +70,10 @@ class PlatformSubCommand {
             val platformPlugin = marketplacePlugin.platform(targetPlatform)
                 ?: return audience.sendFailure("${marketplacePlugin.name} is not available on ${targetPlatform.name}.")
 
-            val targetVersion = platformPlugin.newestCompatibleVersion(localPlugin.preferredChannel, currentServerTypePreference())
+            val serverTypes = currentServerTypePreference()
+            val targetVersion = platformPlugin.newestCompatibleVersionWithFallback(localPlugin.preferredChannel, serverTypes) {
+                API.getPluginVersions(platformPlugin.platformWithId)?.toList()
+            }
                 ?: return audience.sendFailure("No compatible version found on ${targetPlatform.name} for ${localPlugin.preferredChannel ?: "the default channel"}.")
 
             audience.sendInfo("Switching ${localPlugin.name} from ${localPlugin.platform.name} to ${targetPlatform.name}...")

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/PlatformSubCommand.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/PlatformSubCommand.kt
@@ -13,6 +13,7 @@ import gg.flyte.pluginportal.common.types.LocalPlugin
 import gg.flyte.pluginportal.common.types.newestCompatibleVersionWithFallback
 import gg.flyte.pluginportal.common.types.enums.MarketplacePlatform
 import gg.flyte.pluginportal.common.util.async
+import gg.flyte.pluginportal.common.util.currentMinecraftVersion
 import gg.flyte.pluginportal.common.util.currentServerTypePreference
 import gg.flyte.pluginportal.common.util.download
 import net.kyori.adventure.audience.Audience
@@ -71,7 +72,8 @@ class PlatformSubCommand {
                 ?: return audience.sendFailure("${marketplacePlugin.name} is not available on ${targetPlatform.name}.")
 
             val serverTypes = currentServerTypePreference()
-            val targetVersion = platformPlugin.newestCompatibleVersionWithFallback(localPlugin.preferredChannel, serverTypes) {
+            val minecraftVersion = currentMinecraftVersion()
+            val targetVersion = platformPlugin.newestCompatibleVersionWithFallback(localPlugin.preferredChannel, serverTypes, minecraftVersion) {
                 API.getPluginVersions(platformPlugin.platformWithId)?.toList()
             }
                 ?: return audience.sendFailure("No compatible version found on ${targetPlatform.name} for ${localPlugin.preferredChannel ?: "the default channel"}.")

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/UpdateSubCommand.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/UpdateSubCommand.kt
@@ -14,9 +14,10 @@ import gg.flyte.pluginportal.common.types.ExactVersionSelection
 import gg.flyte.pluginportal.common.types.LocalPlugin
 import gg.flyte.pluginportal.common.types.Plugin
 import gg.flyte.pluginportal.common.types.Version
-import gg.flyte.pluginportal.common.types.exactCompatibleVersion
+import gg.flyte.pluginportal.common.types.exactCompatibleVersionWithFallback
 import gg.flyte.pluginportal.common.util.SharedComponents
 import gg.flyte.pluginportal.common.util.async
+import gg.flyte.pluginportal.common.util.currentMinecraftVersion
 import gg.flyte.pluginportal.common.util.currentServerTypePreference
 import net.kyori.adventure.audience.Audience
 import revxrsal.commands.annotation.*
@@ -66,15 +67,12 @@ class UpdateSubCommand {
                 ?: return audience.sendFailure("Could not find plugin in marketplace (${localPlugin.name} with ID ${localPlugin.platformId} on ${localPlugin.platform})")
             val platformPlugin = marketplacePlugin.platform(localPlugin.platform)
                 ?: return audience.sendFailure("${localPlugin.name} is not available on ${localPlugin.platform}")
+            val serverTypes = currentServerTypePreference()
+            val minecraftVersion = currentMinecraftVersion()
 
-            val selection = platformPlugin.exactCompatibleVersion(exactVersionNumber, targetChannel, currentServerTypePreference())
-                .let { initial ->
-                    if (initial != ExactVersionSelection.NotFound) initial
-                    else API.getPluginVersions(platformPlugin.platformWithId)
-                        ?.toList()
-                        ?.exactCompatibleVersion(exactVersionNumber, targetChannel, currentServerTypePreference())
-                        ?: initial
-                }
+            val selection = platformPlugin.exactCompatibleVersionWithFallback(exactVersionNumber, targetChannel, serverTypes, minecraftVersion) {
+                API.getPluginVersions(platformPlugin.platformWithId)?.toList()
+            }
 
             targetVersionOverride = when (selection) {
                 is ExactVersionSelection.Found -> selection.version

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/MarketplacePluginCache.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/MarketplacePluginCache.kt
@@ -10,6 +10,7 @@ import gg.flyte.pluginportal.common.chat.sendFailure
 import gg.flyte.pluginportal.common.logging.PortalLogger
 import gg.flyte.pluginportal.common.types.LocalPlugin
 import gg.flyte.pluginportal.common.types.Plugin
+import gg.flyte.pluginportal.common.types.newestCompatibleVersionWithFallback
 import gg.flyte.pluginportal.common.types.enums.MarketplacePlatform
 import gg.flyte.pluginportal.common.util.*
 import net.kyori.adventure.audience.Audience
@@ -137,12 +138,19 @@ object MarketplacePluginCache: PluginCache<Plugin>() {
         }
 
         val platformPlugin = plugin.platform(platform) ?: return ActionResponseString(false, "No platform plugin found")
-        val latestVersion = platformPlugin.newestCompatibleVersion(null, currentServerTypePreference(), currentMinecraftVersion())
+        val serverTypes = currentServerTypePreference()
+        val minecraftVersion = currentMinecraftVersion()
+        val latestVersion = platformPlugin.newestCompatibleVersionWithFallback(null, serverTypes, minecraftVersion) {
+            API.getPluginVersions(platformPlugin.platformWithId)?.toList()
+        }
             ?: return ActionResponseString(false, "No compatible version found for platform ${platform.name}")
 
-        val downloadURL = latestVersion.downloadURL ?: return ActionResponseString(false, "No download URL found for platform ${platform.name}")
+        val downloadURL = latestVersion.downloadURL
+        if (downloadURL == null && platform != MarketplacePlatform.POLYMART) {
+            return ActionResponseString(false, "No download URL found for platform ${platform.name}")
+        }
 
-        if (!isValidDownload(downloadURL)) {
+        if (downloadURL != null && !isValidDownload(downloadURL)) {
             val errorMsg = when {
                 downloadURL.contains("/versions") || downloadURL.contains("/releases") ->
                     "This plugin uses an external download page instead of a direct download. Please download it manually from: $downloadURL"
@@ -159,7 +167,13 @@ object MarketplacePluginCache: PluginCache<Plugin>() {
         val targetMessage = "${plugin.name} from ${platform.name} with ID ${plugin.id}"
         PortalLogger.log(audience, PortalLogger.Action.INITIATED_INSTALL, targetMessage)
 
-        val newPlugin = plugin.download(false, platform, audience)
+        val newPlugin = plugin.download(
+            false,
+            platform,
+            audience,
+            version = latestVersion,
+            preferredChannel = latestVersion.releaseChannel,
+        )
         return if (newPlugin != null) {
             PortalLogger.log(audience, PortalLogger.Action.INSTALL, targetMessage)
             ActionResponseString(true, "Downloaded ${plugin.name} from ${platform.name}.", newPlugin)

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/MarketplacePluginCache.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/MarketplacePluginCache.kt
@@ -137,7 +137,7 @@ object MarketplacePluginCache: PluginCache<Plugin>() {
         }
 
         val platformPlugin = plugin.platform(platform) ?: return ActionResponseString(false, "No platform plugin found")
-        val latestVersion = platformPlugin.newestCompatibleVersion(null, currentServerTypePreference())
+        val latestVersion = platformPlugin.newestCompatibleVersion(null, currentServerTypePreference(), currentMinecraftVersion())
             ?: return ActionResponseString(false, "No compatible version found for platform ${platform.name}")
 
         val downloadURL = latestVersion.downloadURL ?: return ActionResponseString(false, "No download URL found for platform ${platform.name}")

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/PluginPortalSelfUpdateManager.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/PluginPortalSelfUpdateManager.kt
@@ -3,6 +3,7 @@ package gg.flyte.pluginportal.common.managers
 import gg.flyte.pluginportal.common.API
 import gg.flyte.pluginportal.common.types.Plugin
 import gg.flyte.pluginportal.common.types.Version
+import gg.flyte.pluginportal.common.types.newestCompatibleVersionWithFallback
 import gg.flyte.pluginportal.common.util.PP_PLUGIN_ID
 import gg.flyte.pluginportal.common.util.currentMinecraftVersion
 import gg.flyte.pluginportal.common.util.currentServerTypePreference
@@ -29,7 +30,11 @@ object PluginPortalSelfUpdateManager {
     fun findMarketplaceTarget(channel: String? = null): AvailableUpdate? {
         val plugin = fetchCanonicalPlugin() ?: return null
         val platform = plugin.platforms.bestDownloadable ?: return null
-        val targetVersion = platform.newestCompatibleVersion(normalizeChannel(channel), currentServerTypePreference(), currentMinecraftVersion()) ?: return null
+        val serverTypes = currentServerTypePreference()
+        val minecraftVersion = currentMinecraftVersion()
+        val targetVersion = platform.newestCompatibleVersionWithFallback(normalizeChannel(channel), serverTypes, minecraftVersion) {
+            API.getPluginVersions(platform.platformWithId)?.toList()
+        } ?: return null
         return AvailableUpdate(plugin, targetVersion)
     }
 

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/PluginPortalSelfUpdateManager.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/PluginPortalSelfUpdateManager.kt
@@ -4,6 +4,7 @@ import gg.flyte.pluginportal.common.API
 import gg.flyte.pluginportal.common.types.Plugin
 import gg.flyte.pluginportal.common.types.Version
 import gg.flyte.pluginportal.common.util.PP_PLUGIN_ID
+import gg.flyte.pluginportal.common.util.currentMinecraftVersion
 import gg.flyte.pluginportal.common.util.currentServerTypePreference
 import gg.flyte.pluginportal.common.util.download
 import gg.flyte.pluginportal.common.util.isPluginPortal
@@ -28,7 +29,7 @@ object PluginPortalSelfUpdateManager {
     fun findMarketplaceTarget(channel: String? = null): AvailableUpdate? {
         val plugin = fetchCanonicalPlugin() ?: return null
         val platform = plugin.platforms.bestDownloadable ?: return null
-        val targetVersion = platform.newestCompatibleVersion(normalizeChannel(channel), currentServerTypePreference()) ?: return null
+        val targetVersion = platform.newestCompatibleVersion(normalizeChannel(channel), currentServerTypePreference(), currentMinecraftVersion()) ?: return null
         return AvailableUpdate(plugin, targetVersion)
     }
 

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/types/LocalPlugin.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/types/LocalPlugin.kt
@@ -5,6 +5,7 @@ import gg.flyte.pluginportal.common.PlatformId
 import gg.flyte.pluginportal.common.PluginPortalBase
 import gg.flyte.pluginportal.common.managers.MarketplacePluginCache
 import gg.flyte.pluginportal.common.types.enums.MarketplacePlatform
+import gg.flyte.pluginportal.common.util.currentMinecraftVersion
 import gg.flyte.pluginportal.common.util.currentServerTypePreference
 
 /** Represents a plugin that is installed on the local server. */
@@ -27,28 +28,31 @@ data class LocalPlugin(
         ?: MarketplacePluginCache.getOrFetchPluginById(platform, platformId)
         ?: throw LocalPluginException(1, "Could not retrieve plugin")
 
-    private val serverPlatform get() = marketplacePlugin.platform(platform) ?: throw LocalPluginException(2, "Could not retrieve platform/versions")
-    private val serverTypedVersions get() = serverPlatform.compatibleVersions(currentServerTypePreference())
-
     val isUpToDate: Boolean get() {
-        if (serverTypedVersions.isEmpty()) {
+        val target = targetUpdateVersion()
+        if (target == null) {
             PluginPortalBase.plugin.logger.warning("No compatible versions for $name ($platform $platformId)")
             return false
         }
-        val target = targetUpdateVersion() ?: return false
         return matchesVersion(target)
     }
 
     fun targetUpdateVersion(plugin: Plugin = marketplacePlugin): Version? {
         val platformPlugin = plugin.platform(platform) ?: return null
         val serverTypes = currentServerTypePreference()
-        val cachedTarget = platformPlugin.newestCompatibleVersion(preferredChannel, serverTypes)
+        val minecraftVersion = currentMinecraftVersion()
+        val cachedTarget = platformPlugin.newestCompatibleVersion(preferredChannel, serverTypes, minecraftVersion)
 
-        if (cachedTarget != null && !matchesVersion(cachedTarget)) return cachedTarget
+        if (
+            cachedTarget != null
+            && !matchesVersion(cachedTarget)
+            && cachedTarget.bestServerTypeRank(serverTypes) == 0
+            && (minecraftVersion == null || cachedTarget.explicitlySupportsMinecraftVersion(minecraftVersion))
+        ) return cachedTarget
 
         val fullTarget = API.getPluginVersions(platformPlugin.platformWithId)
             ?.toList()
-            ?.newestCompatibleVersion(preferredChannel, serverTypes)
+            ?.newestCompatibleVersion(preferredChannel, serverTypes, minecraftVersion)
 
         return fullTarget ?: cachedTarget
     }

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/types/PluginTypes.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/types/PluginTypes.kt
@@ -146,6 +146,14 @@ fun List<Version>.newestCompatibleVersion(channel: String?, serverTypePreference
         .filter { version -> channel == null || version.releaseChannel.equals(channel, ignoreCase = true) }
         .bestCompatibleVersion(serverTypePreference)
 
+fun PlatformPlugin.newestCompatibleVersionWithFallback(
+    channel: String?,
+    serverTypePreference: List<ServerType>,
+    fetchVersions: () -> List<Version>?
+): Version? =
+    newestCompatibleVersion(channel, serverTypePreference)
+        ?: fetchVersions()?.newestCompatibleVersion(channel, serverTypePreference)
+
 // Detailed entry for a plugin on Modrinth
 class ModrinthPlatformEntry(
     entryId: String,

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/types/PluginTypes.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/types/PluginTypes.kt
@@ -91,13 +91,16 @@ abstract class PlatformPlugin(
     val platformWithId get() = PlatformId(platformId, platform)
 
     fun compatibleVersions(serverTypePreference: List<ServerType>): List<Version> =
-        versions.filter { version -> version.isCompatibleWith(serverTypePreference) }
+        versions.compatibleVersions(serverTypePreference)
 
-    fun newestCompatibleVersion(channel: String?, serverTypePreference: List<ServerType>): Version? =
-        versions.newestCompatibleVersion(channel, serverTypePreference)
+    fun compatibleVersions(serverTypePreference: List<ServerType>, minecraftVersion: String?): List<Version> =
+        versions.compatibleVersions(serverTypePreference, minecraftVersion)
 
-    fun exactCompatibleVersion(versionNumber: String, channel: String?, serverTypePreference: List<ServerType>): ExactVersionSelection {
-        return versions.exactCompatibleVersion(versionNumber, channel, serverTypePreference)
+    fun newestCompatibleVersion(channel: String?, serverTypePreference: List<ServerType>, minecraftVersion: String? = null): Version? =
+        versions.newestCompatibleVersion(channel, serverTypePreference, minecraftVersion)
+
+    fun exactCompatibleVersion(versionNumber: String, channel: String?, serverTypePreference: List<ServerType>, minecraftVersion: String? = null): ExactVersionSelection {
+        return versions.exactCompatibleVersion(versionNumber, channel, serverTypePreference, minecraftVersion)
     }
 
     fun newestBukkitPaperVersion(channel: String?): Version? =
@@ -115,10 +118,15 @@ sealed class ExactVersionSelection {
     object NotFound : ExactVersionSelection()
 }
 
-fun List<Version>.exactCompatibleVersion(versionNumber: String, channel: String?, serverTypePreference: List<ServerType>): ExactVersionSelection {
+fun List<Version>.compatibleVersions(serverTypePreference: List<ServerType>, minecraftVersion: String? = null): List<Version> =
+    filter { version -> version.isCompatibleWith(serverTypePreference) }
+        .preferMinecraftVersion(minecraftVersion)
+
+fun List<Version>.exactCompatibleVersion(versionNumber: String, channel: String?, serverTypePreference: List<ServerType>, minecraftVersion: String? = null): ExactVersionSelection {
     val matches = filter { version -> version.isCompatibleWith(serverTypePreference) }
         .filter { version -> version.versionNumber == versionNumber }
         .filter { version -> channel == null || version.releaseChannel.equals(channel, ignoreCase = true) }
+        .preferMinecraftVersion(minecraftVersion)
 
     if (matches.isEmpty()) return ExactVersionSelection.NotFound
 
@@ -141,18 +149,55 @@ private fun List<Version>.bestCompatibleVersion(serverTypePreference: List<Serve
         }
     )
 
-fun List<Version>.newestCompatibleVersion(channel: String?, serverTypePreference: List<ServerType>): Version? =
+fun List<Version>.newestCompatibleVersion(channel: String?, serverTypePreference: List<ServerType>, minecraftVersion: String? = null): Version? =
     filter { version -> version.isCompatibleWith(serverTypePreference) }
         .filter { version -> channel == null || version.releaseChannel.equals(channel, ignoreCase = true) }
+        .preferMinecraftVersion(minecraftVersion)
         .bestCompatibleVersion(serverTypePreference)
 
 fun PlatformPlugin.newestCompatibleVersionWithFallback(
     channel: String?,
     serverTypePreference: List<ServerType>,
+    minecraftVersion: String? = null,
     fetchVersions: () -> List<Version>?
 ): Version? =
-    newestCompatibleVersion(channel, serverTypePreference)
-        ?: fetchVersions()?.newestCompatibleVersion(channel, serverTypePreference)
+    newestCompatibleVersion(channel, serverTypePreference, minecraftVersion)
+        ?.takeIf { version -> version.isSpecificMatch(serverTypePreference, minecraftVersion) }
+        ?: fetchVersions()?.newestCompatibleVersion(channel, serverTypePreference, minecraftVersion)
+        ?: newestCompatibleVersion(channel, serverTypePreference, minecraftVersion)
+
+fun PlatformPlugin.exactCompatibleVersionWithFallback(
+    versionNumber: String,
+    channel: String?,
+    serverTypePreference: List<ServerType>,
+    minecraftVersion: String? = null,
+    fetchVersions: () -> List<Version>?
+): ExactVersionSelection {
+    val cached = exactCompatibleVersion(versionNumber, channel, serverTypePreference, minecraftVersion)
+    if (cached is ExactVersionSelection.Found && cached.version.isSpecificMatch(serverTypePreference, minecraftVersion)) {
+        return cached
+    }
+
+    return when (val full = fetchVersions()?.exactCompatibleVersion(versionNumber, channel, serverTypePreference, minecraftVersion)) {
+        null, ExactVersionSelection.NotFound -> cached
+        else -> full
+    }
+}
+
+private fun List<Version>.preferMinecraftVersion(minecraftVersion: String?): List<Version> {
+    val normalized = normalizeMinecraftVersion(minecraftVersion) ?: return this
+    val explicitMatches = filter { version -> version.explicitlySupportsMinecraftVersion(normalized) }
+    if (explicitMatches.isNotEmpty()) return explicitMatches
+
+    val unknownCompatibility = filter { version -> version.supportedMinecraftVersions.isEmpty() }
+    return unknownCompatibility.ifEmpty { this }
+}
+
+private fun Version.isSpecificMatch(serverTypePreference: List<ServerType>, minecraftVersion: String?): Boolean {
+    val exactServerType = bestServerTypeRank(serverTypePreference) == 0
+    val normalizedMinecraftVersion = normalizeMinecraftVersion(minecraftVersion)
+    return exactServerType && (normalizedMinecraftVersion == null || explicitlySupportsMinecraftVersion(normalizedMinecraftVersion))
+}
 
 // Detailed entry for a plugin on Modrinth
 class ModrinthPlatformEntry(
@@ -239,14 +284,25 @@ data class Version(
     val releaseChannel: String?,
     val downloadURL: String?,
     val supportedVersions: String?,
+    @SerializedName("mcVersions")
+    val mcVersions: List<String>? = null,
     val serverTypes: Array<ServerType>,
     val sha256: String?,
 ) {
+    val supportedMinecraftVersions: List<String>
+        get() = (extractMinecraftVersions(supportedVersions) + mcVersions.orEmpty().mapNotNull(::normalizeMinecraftVersion))
+            .distinct()
+
     val serverPlatforms: Set<ServerPlatform> get() = serverTypes?.map { it.platform }?.toSet() ?: throw NullPointerException("serverTypes array is null!")
     val isBukkitPaper get() = serverPlatforms.let { it.contains(ServerPlatform.BUKKIT) || it.contains(ServerPlatform.PAPER) }
 
     fun isCompatibleWith(serverTypePreference: List<ServerType>): Boolean =
         bestServerTypeRank(serverTypePreference) != Int.MAX_VALUE
+
+    fun explicitlySupportsMinecraftVersion(minecraftVersion: String?): Boolean {
+        val normalized = normalizeMinecraftVersion(minecraftVersion) ?: return false
+        return supportedMinecraftVersions.any { supported -> minecraftVersionsMatch(supported, normalized) }
+    }
 
     fun bestServerTypeRank(serverTypePreference: List<ServerType>): Int {
         val availableTypes = serverTypes.toSet()
@@ -265,6 +321,32 @@ data class Version(
 
         return Int.MAX_VALUE
     }
+}
+
+private val minecraftVersionPattern = Regex("""\b\d+\.\d+(?:\.\d+)?\b""")
+
+private fun extractMinecraftVersions(value: String?): List<String> =
+    value
+        ?.let { minecraftVersionPattern.findAll(it).mapNotNull { match -> normalizeMinecraftVersion(match.value) }.toList() }
+        ?: emptyList()
+
+private fun normalizeMinecraftVersion(value: String?): String? =
+    value
+        ?.let { minecraftVersionPattern.find(it)?.value }
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+
+private fun minecraftVersionsMatch(supported: String, target: String): Boolean {
+    if (supported == target) return true
+    val supportedParts = supported.split(".")
+    val targetParts = target.split(".")
+    if (supportedParts.size == 2 && targetParts.size >= 2) {
+        return supportedParts[0] == targetParts[0] && supportedParts[1] == targetParts[1]
+    }
+    if (targetParts.size == 2 && supportedParts.size >= 2) {
+        return supportedParts[0] == targetParts[0] && supportedParts[1] == targetParts[1]
+    }
+    return false
 }
 
 // Represents the file hashes for a version

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/types/SocketActions.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/types/SocketActions.kt
@@ -1,6 +1,7 @@
 package gg.flyte.pluginportal.common.types
 
 import com.google.gson.JsonObject
+import gg.flyte.pluginportal.common.API
 import gg.flyte.pluginportal.common.Config
 import gg.flyte.pluginportal.common.logging.PortalLogger
 import gg.flyte.pluginportal.common.managers.LocalPluginCache
@@ -32,8 +33,18 @@ class SocketActions {
 
         val platformPlugin = plugin.platform(marketplacePlatform)
             ?: return@SocketAction PluginActionResponse(false, "Plugin not found on $marketplacePlatform")
+        val serverTypes = currentServerTypePreference()
         val version = if (versionNumber != null) {
-            when (val selection = platformPlugin.exactCompatibleVersion(versionNumber, channel, currentServerTypePreference())) {
+            val selection = platformPlugin.exactCompatibleVersion(versionNumber, channel, serverTypes)
+                .let { initial ->
+                    if (initial != ExactVersionSelection.NotFound) initial
+                    else API.getPluginVersions(platformPlugin.platformWithId)
+                        ?.toList()
+                        ?.exactCompatibleVersion(versionNumber, channel, serverTypes)
+                        ?: initial
+                }
+
+            when (selection) {
                 is ExactVersionSelection.Found -> selection.version
                 is ExactVersionSelection.Ambiguous ->
                     return@SocketAction PluginActionResponse(false, "Multiple compatible versions named $versionNumber exist. Select a release channel.")
@@ -41,7 +52,9 @@ class SocketActions {
                     return@SocketAction PluginActionResponse(false, "No compatible version found for $versionNumber")
             }
         } else {
-            platformPlugin.newestCompatibleVersion(channel, currentServerTypePreference())
+            platformPlugin.newestCompatibleVersionWithFallback(channel, serverTypes) {
+                API.getPluginVersions(platformPlugin.platformWithId)?.toList()
+            }
                 ?: return@SocketAction PluginActionResponse(false, "No compatible version found")
         }
 
@@ -134,7 +147,10 @@ class SocketActions {
             ?: return@SocketAction PluginActionResponse(false, "Plugin not found")
         val platformPlugin = marketplacePlugin.platform(targetPlatform)
             ?: return@SocketAction PluginActionResponse(false, "${marketplacePlugin.name} is not available on $targetPlatform")
-        val version = platformPlugin.newestCompatibleVersion(localPlugin.preferredChannel, currentServerTypePreference())
+        val serverTypes = currentServerTypePreference()
+        val version = platformPlugin.newestCompatibleVersionWithFallback(localPlugin.preferredChannel, serverTypes) {
+            API.getPluginVersions(platformPlugin.platformWithId)?.toList()
+        }
             ?: return@SocketAction PluginActionResponse(false, "No compatible version found")
 
         val newPlugin = marketplacePlugin.download(

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/types/SocketActions.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/types/SocketActions.kt
@@ -11,6 +11,7 @@ import gg.flyte.pluginportal.common.managers.PluginModificationManager
 import gg.flyte.pluginportal.common.notifications.DiscordWebhookNotifier
 import gg.flyte.pluginportal.common.types.enums.MarketplacePlatform
 import gg.flyte.pluginportal.common.util.ActionResponseString
+import gg.flyte.pluginportal.common.util.currentMinecraftVersion
 import gg.flyte.pluginportal.common.util.currentServerTypePreference
 import gg.flyte.pluginportal.common.util.download
 import net.kyori.adventure.audience.Audience
@@ -34,15 +35,11 @@ class SocketActions {
         val platformPlugin = plugin.platform(marketplacePlatform)
             ?: return@SocketAction PluginActionResponse(false, "Plugin not found on $marketplacePlatform")
         val serverTypes = currentServerTypePreference()
+        val minecraftVersion = currentMinecraftVersion()
         val version = if (versionNumber != null) {
-            val selection = platformPlugin.exactCompatibleVersion(versionNumber, channel, serverTypes)
-                .let { initial ->
-                    if (initial != ExactVersionSelection.NotFound) initial
-                    else API.getPluginVersions(platformPlugin.platformWithId)
-                        ?.toList()
-                        ?.exactCompatibleVersion(versionNumber, channel, serverTypes)
-                        ?: initial
-                }
+            val selection = platformPlugin.exactCompatibleVersionWithFallback(versionNumber, channel, serverTypes, minecraftVersion) {
+                API.getPluginVersions(platformPlugin.platformWithId)?.toList()
+            }
 
             when (selection) {
                 is ExactVersionSelection.Found -> selection.version
@@ -52,7 +49,7 @@ class SocketActions {
                     return@SocketAction PluginActionResponse(false, "No compatible version found for $versionNumber")
             }
         } else {
-            platformPlugin.newestCompatibleVersionWithFallback(channel, serverTypes) {
+            platformPlugin.newestCompatibleVersionWithFallback(channel, serverTypes, minecraftVersion) {
                 API.getPluginVersions(platformPlugin.platformWithId)?.toList()
             }
                 ?: return@SocketAction PluginActionResponse(false, "No compatible version found")
@@ -148,7 +145,8 @@ class SocketActions {
         val platformPlugin = marketplacePlugin.platform(targetPlatform)
             ?: return@SocketAction PluginActionResponse(false, "${marketplacePlugin.name} is not available on $targetPlatform")
         val serverTypes = currentServerTypePreference()
-        val version = platformPlugin.newestCompatibleVersionWithFallback(localPlugin.preferredChannel, serverTypes) {
+        val minecraftVersion = currentMinecraftVersion()
+        val version = platformPlugin.newestCompatibleVersionWithFallback(localPlugin.preferredChannel, serverTypes, minecraftVersion) {
             API.getPluginVersions(platformPlugin.platformWithId)?.toList()
         }
             ?: return@SocketAction PluginActionResponse(false, "No compatible version found")

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/util/ChatImage.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/util/ChatImage.kt
@@ -176,7 +176,7 @@ fun Plugin.buildMoreTooltip(): Component {
             .append(text(platform.lastModified?.toString() ?: "Unknown"))
 
         // Add version info with Folia support
-        platform.newestCompatibleVersion(null, currentServerTypePreference())?.let { version ->
+        platform.newestCompatibleVersion(null, currentServerTypePreference(), currentMinecraftVersion())?.let { version ->
             tooltip = tooltip.append(Component.newline()).appendSecondary("Latest Version: ").append(text(version.versionNumber))
 
             tooltip = tooltip.append(Component.newline()).appendSecondary("Supports Folia: ")
@@ -196,7 +196,7 @@ fun Plugin.getImageComponent(): Component {
     val localPlugin = LocalPluginCache.fromPlugin(this)
     val installed = localPlugin != null
     val supportedVersions = platforms.best
-        ?.newestCompatibleVersion(null, currentServerTypePreference())
+        ?.newestCompatibleVersion(null, currentServerTypePreference(), currentMinecraftVersion())
         ?.supportLabel
         ?: "Unknown"
 
@@ -229,7 +229,7 @@ fun Plugin.getImageComponent(): Component {
 }
 
 private val Version.supportLabel: String
-    get() = supportedVersions?.takeIf { it.isNotBlank() }
+    get() = supportedMinecraftVersions.takeIf { it.isNotEmpty() }?.joinToString(", ")
         ?: serverTypes.joinToString(", ") { it.name.lowercase() }.takeIf { it.isNotBlank() }
         ?: "Unknown"
 

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/util/Http.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/util/Http.kt
@@ -1,6 +1,7 @@
 package gg.flyte.pluginportal.common.util
 
 import gg.flyte.pluginportal.common.AuthCreds
+import gg.flyte.pluginportal.common.API
 import gg.flyte.pluginportal.common.Config
 import gg.flyte.pluginportal.common.Constants
 import gg.flyte.pluginportal.common.PluginPortalBase
@@ -12,6 +13,7 @@ import gg.flyte.pluginportal.common.types.LocalPlugin
 import gg.flyte.pluginportal.common.types.Plugin
 import gg.flyte.pluginportal.common.types.PolymartPlatformEntry
 import gg.flyte.pluginportal.common.types.Version
+import gg.flyte.pluginportal.common.types.newestCompatibleVersionWithFallback
 import gg.flyte.pluginportal.common.types.enums.MarketplacePlatform
 import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.text.Component.text
@@ -60,8 +62,12 @@ fun Plugin.download(
     }
     val targetDir = if (update) Constants.UPDATE_DIRECTORY else Constants.INSTALL_DIRECTORY
     val jarFile = File(targetDir, getFullDownloadedName(platform))
+    val serverTypes = currentServerTypePreference()
+    val minecraftVersion = currentMinecraftVersion()
     val version = version
-        ?: platformPlugin.newestCompatibleVersion(preferredChannel, currentServerTypePreference(), currentMinecraftVersion())
+        ?: platformPlugin.newestCompatibleVersionWithFallback(preferredChannel, serverTypes, minecraftVersion) {
+            API.getPluginVersions(platformPlugin.platformWithId)?.toList()
+        }
         ?: run {
             audience.logFailure(
                 "No compatible version found for ${preferredChannel ?: "the default channel"}",

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/util/Http.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/util/Http.kt
@@ -10,9 +10,9 @@ import gg.flyte.pluginportal.common.managers.MarketplacePluginCache
 import gg.flyte.pluginportal.common.notifications.DiscordWebhookNotifier
 import gg.flyte.pluginportal.common.types.LocalPlugin
 import gg.flyte.pluginportal.common.types.Plugin
+import gg.flyte.pluginportal.common.types.PolymartPlatformEntry
 import gg.flyte.pluginportal.common.types.Version
 import gg.flyte.pluginportal.common.types.enums.MarketplacePlatform
-import gg.flyte.pluginportal.common.util.currentServerTypePreference
 import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.text.Component.text
 import java.io.File
@@ -75,7 +75,19 @@ fun Plugin.download(
         return null
     }
 
-    val downloadUrl = version.downloadURL
+    val downloadUrl = version.downloadURL ?: if (platform == MarketplacePlatform.POLYMART) {
+        val polymart = platformPlugin as? PolymartPlatformEntry
+        if (polymart?.premium != null) {
+            audience.logFailure(
+                "Downloading premium Polymart plugins is currently not supported.",
+                "Unable to download premium Polymart plugin $name (${platformPlugin.platformId})"
+            )
+            return null
+        }
+        getPolymartDownloadUrl(platformPlugin.platformId)
+    } else {
+        null
+    }
 
     if (downloadUrl == null) {
         audience.logFailure("""
@@ -86,7 +98,7 @@ fun Plugin.download(
     }
 
     val file = download(
-        URL(version.downloadURL),
+        URL(downloadUrl),
         jarFile,
         audience
     ) ?: return null

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/util/Http.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/util/Http.kt
@@ -61,7 +61,7 @@ fun Plugin.download(
     val targetDir = if (update) Constants.UPDATE_DIRECTORY else Constants.INSTALL_DIRECTORY
     val jarFile = File(targetDir, getFullDownloadedName(platform))
     val version = version
-        ?: platformPlugin.newestCompatibleVersion(preferredChannel, currentServerTypePreference())
+        ?: platformPlugin.newestCompatibleVersion(preferredChannel, currentServerTypePreference(), currentMinecraftVersion())
         ?: run {
             audience.logFailure(
                 "No compatible version found for ${preferredChannel ?: "the default channel"}",

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/util/Polymart.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/util/Polymart.kt
@@ -1,0 +1,45 @@
+package gg.flyte.pluginportal.common.util
+
+import com.google.gson.JsonObject
+import gg.flyte.pluginportal.common.PluginPortalBase
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
+
+fun getPolymartDownloadUrl(resourceId: String, token: String? = null): String? = runCatching {
+    val url = URL("https://api.polymart.org/v1/getDownloadURL")
+    val connection = url.openConnection() as HttpURLConnection
+    connection.requestMethod = "POST"
+    connection.doOutput = true
+    connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
+
+    val postData = buildString {
+        append("resource_id=${URLEncoder.encode(resourceId, "UTF-8")}")
+        if (!token.isNullOrBlank()) {
+            append("&token=${URLEncoder.encode(token, "UTF-8")}")
+        }
+    }
+
+    connection.outputStream.use { it.write(postData.toByteArray()) }
+
+    if (connection.responseCode != 200) {
+        PluginPortalBase.plugin.logger.warning("Polymart download URL request failed with HTTP ${connection.responseCode}")
+        return@runCatching null
+    }
+
+    val response = connection.inputStream.bufferedReader().use { it.readText() }
+    val json = GSON.fromJson(response, JsonObject::class.java)
+    if (json.getAsJsonObject("response")?.get("success")?.asBoolean == true) {
+        json.getAsJsonObject("response")
+            ?.getAsJsonObject("result")
+            ?.get("url")
+            ?.asString
+    } else {
+        val error = json.getAsJsonObject("response")?.get("message")?.asString
+        PluginPortalBase.plugin.logger.warning("Polymart download URL request failed: ${error ?: "unknown error"}")
+        null
+    }
+}.getOrElse {
+    PluginPortalBase.plugin.logger.warning("Polymart download URL request failed: ${it.message ?: it::class.simpleName}")
+    null
+}

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/util/ServerRuntime.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/util/ServerRuntime.kt
@@ -19,9 +19,21 @@ fun currentServerTypePreference(): List<ServerType> {
     }
 }
 
+fun currentMinecraftVersion(): String? =
+    normalizeMinecraftVersion(runCatching { Bukkit.getServer().bukkitVersion }.getOrNull())
+        ?: normalizeMinecraftVersion(runCatching { Bukkit.getServer().version }.getOrNull())
+
 private fun isPaperServer(descriptor: String): Boolean =
     "paper" in descriptor || runCatching {
         Class.forName("com.destroystokyo.paper.PaperConfig")
     }.isSuccess || runCatching {
         Class.forName("io.papermc.paper.configuration.Configuration")
     }.isSuccess
+
+private val minecraftVersionPattern = Regex("""\b\d+\.\d+(?:\.\d+)?\b""")
+
+private fun normalizeMinecraftVersion(value: String?): String? =
+    value
+        ?.let { minecraftVersionPattern.find(it)?.value }
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }

--- a/common/src/test/kotlin/gg/flyte/pluginportal/common/APIPaginationTest.kt
+++ b/common/src/test/kotlin/gg/flyte/pluginportal/common/APIPaginationTest.kt
@@ -1,0 +1,36 @@
+package gg.flyte.pluginportal.common
+
+import gg.flyte.pluginportal.common.types.Pagination
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class APIPaginationTest {
+    @Test
+    fun `advances to the next platform version page while more results exist`() {
+        val pagination = Pagination(total = 750, limit = 500, offset = 0, hasMore = true)
+
+        assertEquals(500, nextPlatformVersionsOffset(pagination, currentOffset = 0, receivedCount = 500))
+    }
+
+    @Test
+    fun `stops platform version paging when there are no more results`() {
+        val pagination = Pagination(total = 500, limit = 500, offset = 0, hasMore = false)
+
+        assertNull(nextPlatformVersionsOffset(pagination, currentOffset = 0, receivedCount = 500))
+    }
+
+    @Test
+    fun `stops platform version paging on empty pages`() {
+        val pagination = Pagination(total = 750, limit = 500, offset = 500, hasMore = true)
+
+        assertNull(nextPlatformVersionsOffset(pagination, currentOffset = 500, receivedCount = 0))
+    }
+
+    @Test
+    fun `stops platform version paging when pagination does not advance`() {
+        val pagination = Pagination(total = 750, limit = 0, offset = 500, hasMore = true)
+
+        assertNull(nextPlatformVersionsOffset(pagination, currentOffset = 500, receivedCount = 100))
+    }
+}

--- a/common/src/test/kotlin/gg/flyte/pluginportal/common/types/VersionSelectionTest.kt
+++ b/common/src/test/kotlin/gg/flyte/pluginportal/common/types/VersionSelectionTest.kt
@@ -90,17 +90,77 @@ class VersionSelectionTest {
         assertEquals("v5.5.53-bukkit", selected?.versionNumber)
     }
 
+    @Test
+    fun `prefers current minecraft version over newer wrong-version builds`() {
+        val versions = listOf(
+            version("2.0.0", "2026-06-02T00:00:00Z", ServerType.PAPER, minecraftVersions = listOf("1.20.6")),
+            version("1.9.0", "2026-06-01T00:00:00Z", ServerType.PAPER, minecraftVersions = listOf("1.21.4")),
+        )
+
+        val selected = versions.newestCompatibleVersion("release", listOf(ServerType.PAPER, ServerType.SPIGOT, ServerType.BUKKIT), "1.21.4")
+
+        assertEquals("1.9.0", selected?.versionNumber)
+    }
+
+    @Test
+    fun `treats minor minecraft versions as family compatibility`() {
+        val versions = listOf(
+            version("1.0.0", "2026-06-01T00:00:00Z", ServerType.PAPER, minecraftVersions = listOf("1.21")),
+        )
+
+        val selected = versions.newestCompatibleVersion("release", listOf(ServerType.PAPER), "1.21.4")
+
+        assertEquals("1.0.0", selected?.versionNumber)
+    }
+
+    @Test
+    fun `falls back to full version list when cached slice only has a server type fallback`() {
+        val platform = platformEntry(
+            versions = listOf(
+                version("1.1.0-bukkit", "2026-06-02T00:00:00Z", ServerType.BUKKIT, minecraftVersions = listOf("1.21.4")),
+            )
+        )
+
+        val selected = platform.newestCompatibleVersionWithFallback("release", listOf(ServerType.PAPER, ServerType.SPIGOT, ServerType.BUKKIT), "1.21.4") {
+            listOf(
+                version("1.0.0-paper", "2026-06-01T00:00:00Z", ServerType.PAPER, minecraftVersions = listOf("1.21.4"))
+            )
+        }
+
+        assertEquals("1.0.0-paper", selected?.versionNumber)
+    }
+
+    @Test
+    fun `exact version fallback prefers exact server type from full version list`() {
+        val platform = platformEntry(
+            versions = listOf(
+                version("1.0.0", "2026-06-02T00:00:00Z", ServerType.BUKKIT, minecraftVersions = listOf("1.21.4")),
+            )
+        )
+
+        val selection = platform.exactCompatibleVersionWithFallback("1.0.0", "release", listOf(ServerType.PAPER, ServerType.SPIGOT, ServerType.BUKKIT), "1.21.4") {
+            listOf(
+                version("1.0.0", "2026-06-01T00:00:00Z", ServerType.PAPER, minecraftVersions = listOf("1.21.4"))
+            )
+        }
+
+        assertEquals("1.0.0", (selection as ExactVersionSelection.Found).version.versionNumber)
+        assertEquals(0, selection.version.bestServerTypeRank(listOf(ServerType.PAPER, ServerType.SPIGOT, ServerType.BUKKIT)))
+    }
+
     private fun version(
         versionNumber: String,
         releasedAt: String,
         vararg serverTypes: ServerType,
         channel: String = "release",
+        minecraftVersions: List<String>? = null,
     ) = Version(
         versionNumber = versionNumber,
         releasedAt = Date.from(Instant.parse(releasedAt)),
         releaseChannel = channel,
         downloadURL = "https://example.com/$versionNumber.jar",
         supportedVersions = null,
+        mcVersions = minecraftVersions,
         serverTypes = arrayOf(*serverTypes),
         sha256 = null,
     )

--- a/common/src/test/kotlin/gg/flyte/pluginportal/common/types/VersionSelectionTest.kt
+++ b/common/src/test/kotlin/gg/flyte/pluginportal/common/types/VersionSelectionTest.kt
@@ -70,6 +70,26 @@ class VersionSelectionTest {
         assertEquals("1.0.0-paper", selected?.versionNumber)
     }
 
+    @Test
+    fun `falls back to full version list when cached marketplace slice has no compatible version`() {
+        val platform = platformEntry(
+            versions = listOf(
+                version("v5.5.57-neoforge", "2026-06-18T21:16:30Z", ServerType.NEOFORGE),
+                version("v5.5.57-fabric", "2026-06-18T21:16:14Z", ServerType.FABRIC),
+                version("v5.5.57-forge", "2026-06-18T21:15:58Z", ServerType.FORGE),
+                version("v5.5.53-velocity", "2026-05-27T07:14:53Z", ServerType.VELOCITY),
+            )
+        )
+
+        val selected = platform.newestCompatibleVersionWithFallback("release", listOf(ServerType.PAPER, ServerType.SPIGOT, ServerType.BUKKIT)) {
+            listOf(
+                version("v5.5.53-bukkit", "2026-05-27T07:14:37Z", ServerType.BUKKIT, ServerType.SPIGOT, ServerType.PAPER)
+            )
+        }
+
+        assertEquals("v5.5.53-bukkit", selected?.versionNumber)
+    }
+
     private fun version(
         versionNumber: String,
         releasedAt: String,
@@ -83,5 +103,19 @@ class VersionSelectionTest {
         supportedVersions = null,
         serverTypes = arrayOf(*serverTypes),
         sha256 = null,
+    )
+
+    private fun platformEntry(versions: List<Version>) = ModrinthPlatformEntry(
+        entryId = "entry",
+        platform = gg.flyte.pluginportal.common.types.enums.MarketplacePlatform.MODRINTH,
+        platformId = "luckperms",
+        author = "lucko",
+        description = null,
+        iconURL = null,
+        downloads = 0,
+        lastModified = null,
+        versions = versions,
+        followers = 0,
+        lastSynced = Date.from(Instant.parse("2026-06-18T21:16:30Z")),
     )
 }

--- a/common/src/test/kotlin/gg/flyte/pluginportal/common/types/VersionSelectionTest.kt
+++ b/common/src/test/kotlin/gg/flyte/pluginportal/common/types/VersionSelectionTest.kt
@@ -91,6 +91,19 @@ class VersionSelectionTest {
     }
 
     @Test
+    fun `falls back to full version list when cached marketplace slice is empty`() {
+        val platform = platformEntry(versions = emptyList())
+
+        val selected = platform.newestCompatibleVersionWithFallback("release", listOf(ServerType.PAPER, ServerType.SPIGOT, ServerType.BUKKIT)) {
+            listOf(
+                version("1.0.0-paper", "2026-06-01T00:00:00Z", ServerType.PAPER)
+            )
+        }
+
+        assertEquals("1.0.0-paper", selected?.versionNumber)
+    }
+
+    @Test
     fun `prefers current minecraft version over newer wrong-version builds`() {
         val versions = listOf(
             version("2.0.0", "2026-06-02T00:00:00Z", ServerType.PAPER, minecraftVersions = listOf("1.20.6")),

--- a/plugin/src/main/kotlin/gg/flyte/pluginportal/plugin/commands/ImportSubCommand.kt
+++ b/plugin/src/main/kotlin/gg/flyte/pluginportal/plugin/commands/ImportSubCommand.kt
@@ -58,7 +58,9 @@ class ImportSubCommand {
 
                 // Get plugin details from API
                 val pluginMap: Map<MarketplacePlatform, Map<String, Plugin?>> = API.getAllPluginsByPlatformIds(platformIds.toList()) ?: return@async audience.sendFailure("Failed to fetch plugin details")
-                val plugins = pluginMap.values.flatMap { it.entries }
+                val plugins = platformIds.map { platformId ->
+                    platformId to pluginMap[platformId.platform]?.get(platformId.platformId)
+                }
 
                 // Build initial message
                 var messageComponent: TextComponent = text("")
@@ -67,11 +69,11 @@ class ImportSubCommand {
                     .append(newline())
 
                 // List all plugins to be installed
-                plugins.forEach { (id, plugin) ->
-                    val platform = plugin?.bestPlatform
+                plugins.forEach { (platformId, plugin) ->
+                    val platform = plugin?.platform(platformId.platform)?.platform
                     messageComponent = messageComponent
                         .append(textSecondary(" • "))
-                        .append(textPrimary(plugin?.name ?: id))
+                        .append(textPrimary(plugin?.name ?: platformId.platformId))
                         .append(text(" from ", NamedTextColor.DARK_GRAY))
                         .append(text(platform?.name ?: "NOT FOUND", NamedTextColor.AQUA))
                         .append(newline())
@@ -86,7 +88,7 @@ class ImportSubCommand {
                 var skipCount = 0
                 var failCount = 0
 
-                for (plugin in plugins.mapNotNull { it.value }) {
+                for ((platformId, plugin) in plugins.mapNotNull { (platformId, plugin) -> plugin?.let { platformId to it } }) {
                     if (LocalPluginCache.hasPlugin(plugin)) {
                         skipCount++
                         audience.sendMessage(status(Status.WARNING, "Skipping ${plugin.name} (already installed)").append(newline()))
@@ -94,7 +96,7 @@ class ImportSubCommand {
                     }
 
                     try {
-                        val platform = plugin.bestPlatform
+                        val platform = plugin.platform(platformId.platform)?.platform
 
                         audience.sendMessage(
                             startLine()
@@ -106,7 +108,11 @@ class ImportSubCommand {
                                 .append(endLine())
                         )
 
-                        if (platform == null) return@async audience.sendFailure("Could not find an available platform")
+                        if (platform == null) {
+                            audience.sendFailure("Could not find ${platformId.platform.name} data for ${plugin.name}")
+                            failCount++
+                            continue
+                        }
 
                         val response = MarketplacePluginCache.installPlugin(
                             audience,


### PR DESCRIPTION
## Summary

- Make install, update, platform-switch, import, and Plugin Portal self-update flows fall back to full paginated version lists when the cached marketplace slice does not include a compatible server build.
- Prefer the most specific compatible server type for Paper/Folia-style runtimes while preserving channel and Minecraft-version matching.
- Preserve exported platform identity during `/pp import` so imported SpigotMC/Hangar/Modrinth/Polymart ids do not silently switch marketplaces.
- Support free Polymart plugin downloads through the dynamic download URL path.

## Root Cause

The plugin runtime could receive a merged plugin record whose first cached versions were newer but incompatible for the current server type, or whose desired platform was not the record's default best platform. That made Plugin Portal report no update or install from the wrong marketplace even though the API/scanner had enough data to recover through platform-specific version pagination.

## Validation

- `./gradlew :common:test --tests 'gg.flyte.pluginportal.common.types.VersionSelectionTest' --tests 'gg.flyte.pluginportal.common.APIPaginationTest'` passed.
- `./gradlew :plugin:compileKotlin` passed.
- Re-ran `./gradlew :plugin:compileKotlin` after a Kotlin incremental-cache fallback warning; the rerun passed cleanly with all tasks up to date.
- `git diff --check origin/master..HEAD` passed.

## Notes

- This PR contains only plugin-side source changes and targets the public `flytegg/plugin-portal` repository.
- API/scanner service changes remain in the closed-source API repository PR and are not included here.
- No production deploys, marketplace writes, or release uploads were performed.