### PR TITLE
External finishes

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -146,8 +146,10 @@ asset regex that matches exactly one release asset. GeyserMC sources require an
 artifact name such as `spigot`, `bungee`, or `velocity`.
 
 External plugin IDs may contain letters, numbers, underscores, and hyphens. Each
-entry must use a unique target filename. GitHub releases with no matching asset are
-skipped, while multiple matching assets in the newest applicable release are
+entry must use a unique target filename. When `file` is omitted or a plugin is
+created through `/pp external add`, Plugin Portal uses a managed stable filename
+such as `[PP] viaversion [GITHUB].jar`. GitHub releases with no matching asset
+are skipped, while multiple matching assets in the newest applicable release are
 reported as an ambiguity instead of falling back to an older release.
 
 ```yaml
@@ -155,19 +157,23 @@ plugins:
   floodgate:
     source: geysermc:floodgate
     artifact: spigot
-    file: floodgate-spigot.jar
+    file: "[PP] floodgate [GEYSERMC].jar"
     updates: manual
 
   viaversion:
     source: github:ViaVersion/ViaVersion
     asset: "^ViaVersion.*\\.jar$"
-    file: ViaVersion.jar
+    file: "[PP] viaversion [GITHUB].jar"
     prereleases: false
     updates: manual
 ```
 
 | Command | Purpose |
 | --- | --- |
+| `/pp external add github <id> <owner> <repo> <asset> [--prereleases]` | Add a GitHub external plugin entry using a managed `[PP] ... [GITHUB].jar` filename. `<asset>` may be a simple include string like `ViaVersion` or a full regex. |
+| `/pp external add geysermc <id> <project> <artifact>` | Add a GeyserMC external plugin entry using a managed `[PP] ... [GEYSERMC].jar` filename. |
+| `/pp external import github <id> <owner> <repo> <asset> <file> [--prereleases]` | Track an already installed JAR as a GitHub external plugin. `<asset>` may be a simple include string like `ViaVersion` or a full regex. |
+| `/pp external import geysermc <id> <project> <artifact> <file>` | Track an already installed JAR as a GeyserMC external plugin. |
 | `/pp external check <id>` | Resolve the latest matching provider artifact without downloading it. |
 | `/pp external install <id>` | Install a configured external plugin into `plugins/`. |
 | `/pp external update <id>` | Stage an installed external plugin update in `plugins/update/`. |

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -293,7 +293,7 @@ Export/import:
 | `/pp help` | `pluginportal.view` | Show command help. | Also works by running `/pp`. |
 | `/pp info` | `pluginportal.view` | Show Plugin Portal version, edition, license state, and update info. | Alias: `/pp version`. |
 | `/pp version` | `pluginportal.view` | Same as `/pp info`. | Shows Licensed: Yes/No. |
-| `/pp list` | `pluginportal.view` | List marketplace and external plugins managed by Plugin Portal. | Checks and displays update status; marketplace entries include update/uninstall buttons in player chat. |
+| `/pp list [--all]` | `pluginportal.view` | List marketplace and external plugins managed by Plugin Portal. | Checks and displays update status; `--all` also shows unrecognized JARs in `plugins/`. |
 | `/pp dump` | `pluginportal.dump` | Upload logs/support dump to MCLogs and return a support URL. | Use for diagnostics. |
 | `/pluginportal config refresh` | `pluginportal.manage.config` | Reload local plugin cache/config state. | Command root is `pluginportal config`, not `/pp config`. |
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ enforcement, not by a separate premium artifact.
 | `/pp install <name\|id> [platform] [channel] [--byId] [--exact] [--version <version>]` | `pluginportal.manage.install` | Install a plugin from a marketplace. |
 | `/pp update <name\|id> [--byId] [--channel <name>] [--version <version>]` | `pluginportal.maintain.update` | Update a tracked plugin. |
 | `/pp updateAll` | `pluginportal.maintain.update` | Update all tracked plugins with available updates. |
-| `/pp external <check\|install\|update\|invalidate\|updateAll\|reload>` | `pluginportal.manage.external` | Manage external plugins configured in `external-plugins.yml`. |
+| `/pp external <add\|import\|check\|install\|update\|invalidate\|updateAll\|reload>` | `pluginportal.manage.external` | Manage external plugins configured in `external-plugins.yml`. |
 | `/pp delete <name>` or `/pp uninstall <name>` | `pluginportal.manage.uninstall` | Remove a tracked plugin. |
 | `/pp recognize <file>` / `/pp recognizeAll` | `pluginportal.manage.recognize` | Track manually installed plugin JARs. |
 | `/pp upgrade [--yes]` | `pluginportal.admin` | Check for and install Plugin Portal updates. |

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ enforcement, not by a separate premium artifact.
 | `/pp install <name\|id> [platform] [channel] [--byId] [--exact] [--version <version>]` | `pluginportal.manage.install` | Install a plugin from a marketplace. |
 | `/pp update <name\|id> [--byId] [--channel <name>] [--version <version>]` | `pluginportal.maintain.update` | Update a tracked plugin. |
 | `/pp updateAll` | `pluginportal.maintain.update` | Update all tracked plugins with available updates. |
+| `/pp list [--all]` | `pluginportal.view` | List managed plugins; `--all` also shows unrecognized JARs. |
 | `/pp external <add\|import\|check\|install\|update\|invalidate\|updateAll\|reload>` | `pluginportal.manage.external` | Manage external plugins configured in `external-plugins.yml`. |
 | `/pp delete <name>` or `/pp uninstall <name>` | `pluginportal.manage.uninstall` | Remove a tracked plugin. |
 | `/pp recognize <file>` / `/pp recognizeAll` | `pluginportal.manage.recognize` | Track manually installed plugin JARs. |

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/ListSubCommand.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/ListSubCommand.kt
@@ -235,13 +235,13 @@ class ListSubCommand {
     private fun getCompactUnrecognizedJarLine(jar: UnrecognizedJar): Component =
         Component.text(" - ", NamedTextColor.DARK_GRAY)
             .append(textPrimary(jar.file.name).suggestCommand("/pp recognize \"${jar.file.name}\""))
-            .append(textDark(" (UNRECOGNIZED) "))
+            .append(Component.text(" "))
             .append(recognizeButton(jar.file))
 
     private fun getDetailedUnrecognizedJarLine(jar: UnrecognizedJar): Component =
         Component.text(" - ", NamedTextColor.DARK_GRAY)
             .append(textPrimary(jar.file.name).suggestCommand("/pp recognize \"${jar.file.name}\""))
-            .append(textDark(" (UNRECOGNIZED) "))
+            .append(Component.text(" "))
             .append(textSecondary("sha256="))
             .append(textPrimary(jar.sha256.take(12)))
             .append(Component.text(" "))

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/ListSubCommand.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/ListSubCommand.kt
@@ -206,11 +206,14 @@ class ListSubCommand {
             addAll(adapterManagedHashes())
             add(HashType.SHA256.hash(PluginPortalBase.info.pluginJarFile).lowercase())
         }
+        val externalFileNames = ExternalPluginManager.managedFileNames()
 
         return Constants.INSTALL_DIRECTORY
             .listFiles()
             .orEmpty()
             .filter(File::isJarFile)
+            .filterNot(LocalPluginCache::hasManagedDownloadedFile)
+            .filterNot { it.name.lowercase() in externalFileNames }
             .mapNotNull { file ->
                 val hash = runCatching { HashType.SHA256.hash(file) }.getOrNull() ?: return@mapNotNull null
                 file.takeUnless { hash.lowercase() in managedHashes }?.let { UnrecognizedJar(it, hash) }

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/ListSubCommand.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/ListSubCommand.kt
@@ -1,6 +1,8 @@
 package gg.flyte.pluginportal.common.commands
 
+import com.google.gson.JsonParser
 import gg.flyte.pluginportal.common.PluginPortalBase
+import gg.flyte.pluginportal.common.Constants
 import gg.flyte.pluginportal.common.adapters.external.ExternalPluginConfig
 import gg.flyte.pluginportal.common.adapters.external.ExternalPluginState
 import gg.flyte.pluginportal.common.chat.*
@@ -11,12 +13,16 @@ import gg.flyte.pluginportal.common.managers.ExternalPluginResult
 import gg.flyte.pluginportal.common.managers.LocalPluginCache
 import gg.flyte.pluginportal.common.managers.MarketplacePluginCache
 import gg.flyte.pluginportal.common.types.LocalPlugin
+import gg.flyte.pluginportal.common.util.HashType
 import gg.flyte.pluginportal.common.util.SharedComponents
 import gg.flyte.pluginportal.common.util.async
+import gg.flyte.pluginportal.common.util.isJarFile
 import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.event.ClickEvent
 import net.kyori.adventure.text.event.HoverEvent
 import net.kyori.adventure.text.format.NamedTextColor
+import java.io.File
 import revxrsal.commands.annotation.Command
 import revxrsal.commands.annotation.Subcommand
 import revxrsal.commands.annotation.Switch
@@ -34,6 +40,7 @@ class ListSubCommand {
     fun listCommand(
         audience: Audience,
         @Switch("detailed") detailed: Boolean = false,
+        @Switch("all") all: Boolean = false,
     ) {
         async {
             val plugins = LocalPluginCache
@@ -42,8 +49,9 @@ class ListSubCommand {
             val externalPlugins = ExternalPluginManager.configuredPlugins().map { (config, state) ->
                 ExternalListEntry(config, state, ExternalPluginManager.check(config.id))
             }
+            val unrecognizedJars = if (all) findUnrecognizedJars(plugins, externalPlugins) else emptyList()
 
-            if (plugins.isEmpty() && externalPlugins.isEmpty()) return@async audience.sendMessage(
+            if (plugins.isEmpty() && externalPlugins.isEmpty() && unrecognizedJars.isEmpty()) return@async audience.sendMessage(
                 Component.text("No plugins found", NamedTextColor.GRAY).boxed())
 
             var message = Component.text("Plugins managed by Plugin Portal", NamedTextColor.GRAY)
@@ -58,6 +66,16 @@ class ListSubCommand {
             externalPlugins.forEach { plugin ->
                 message = message.append(Component.text("\n"))
                     .append(if (showDetails) getDetailedExternalPluginLine(plugin) else getCompactExternalPluginLine(plugin))
+            }
+
+            if (unrecognizedJars.isNotEmpty()) {
+                message = message.append(Component.text("\n\n"))
+                    .append(textSecondary("Unrecognized JARs"))
+
+                unrecognizedJars.forEach { jar ->
+                    message = message.append(Component.text("\n"))
+                        .append(if (showDetails) getDetailedUnrecognizedJarLine(jar) else getCompactUnrecognizedJarLine(jar))
+                }
             }
 
             audience.sendMessage(message.boxed())
@@ -174,5 +192,73 @@ class ListSubCommand {
 
         return line
     }
+
+    private fun findUnrecognizedJars(
+        plugins: List<LocalPlugin>,
+        externalPlugins: List<ExternalListEntry>
+    ): List<UnrecognizedJar> {
+        val managedHashes = buildSet {
+            addAll(plugins.map { it.sha256.lowercase() })
+            addAll(ExternalPluginManager.managedHashes())
+            addAll(externalPlugins.flatMap { entry ->
+                listOfNotNull(entry.state?.installed?.sha256, entry.state?.staged?.sha256)
+            }.map(String::lowercase))
+            addAll(adapterManagedHashes())
+            add(HashType.SHA256.hash(PluginPortalBase.info.pluginJarFile).lowercase())
+        }
+
+        return Constants.INSTALL_DIRECTORY
+            .listFiles()
+            .orEmpty()
+            .filter(File::isJarFile)
+            .mapNotNull { file ->
+                val hash = runCatching { HashType.SHA256.hash(file) }.getOrNull() ?: return@mapNotNull null
+                file.takeUnless { hash.lowercase() in managedHashes }?.let { UnrecognizedJar(it, hash) }
+            }
+            .sortedBy { it.file.name.lowercase() }
+    }
+
+    private fun adapterManagedHashes(): Set<String> {
+        val file = File(PluginPortalBase.plugin.dataFolder, "adapter-plugins.json")
+        if (!file.isFile) return emptySet()
+
+        return runCatching {
+            JsonParser.parseString(file.readText()).asJsonArray
+                .mapNotNull { element ->
+                    element.asJsonObject.get("sha256")?.takeUnless { it.isJsonNull }?.asString
+                }
+                .map(String::lowercase)
+                .toSet()
+        }.getOrDefault(emptySet())
+    }
+
+    private fun getCompactUnrecognizedJarLine(jar: UnrecognizedJar): Component =
+        Component.text(" - ", NamedTextColor.DARK_GRAY)
+            .append(textPrimary(jar.file.name).suggestCommand("/pp recognize \"${jar.file.name}\""))
+            .append(textDark(" (UNRECOGNIZED) "))
+            .append(recognizeButton(jar.file))
+
+    private fun getDetailedUnrecognizedJarLine(jar: UnrecognizedJar): Component =
+        Component.text(" - ", NamedTextColor.DARK_GRAY)
+            .append(textPrimary(jar.file.name).suggestCommand("/pp recognize \"${jar.file.name}\""))
+            .append(textDark(" (UNRECOGNIZED) "))
+            .append(textSecondary("sha256="))
+            .append(textPrimary(jar.sha256.take(12)))
+            .append(Component.text(" "))
+            .append(recognizeButton(jar.file))
+
+    private fun recognizeButton(file: File): Component {
+        val command = "/pp recognize \"${file.name}\""
+        return textDark("[")
+            .append(Component.text("RECOGNIZE", NamedTextColor.AQUA))
+            .append(textDark("]"))
+            .hoverEvent(HoverEvent.showText(textSecondary("Click to run $command")))
+            .clickEvent(ClickEvent.runCommand(command))
+    }
+
+    private data class UnrecognizedJar(
+        val file: File,
+        val sha256: String
+    )
 
 }

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/ExternalPluginManager.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/ExternalPluginManager.kt
@@ -271,7 +271,7 @@ object ExternalPluginManager {
             if (destination.exists()) return failure("${config.id} is already installed; use external update")
             removeState(id)
         }
-        if (destination.exists()) return adoptInstalled(config, destination)
+        if (destination.exists()) return adoptMatchingInstalled(config, destination)
         return download(config, destination)
     }
 
@@ -493,14 +493,15 @@ object ExternalPluginManager {
     private fun adoptInstalled(
         config: ExternalPluginConfig,
         pluginFile: File,
-        successMessage: String = "Imported existing ${config.id} from ${relativePath(pluginFile)}"
+        successMessage: String = "Imported existing ${config.id} from ${relativePath(pluginFile)}",
+        resolvedArtifact: ExternalArtifact? = null
     ): ExternalPluginResult {
         if (!pluginFile.isFile) return failure("${config.file} does not exist in ${relativePath(Constants.INSTALL_DIRECTORY)}")
         if (!isJar(pluginFile)) return failure("${config.file} is not a valid JAR")
 
         val hash = HashType.SHA256.hash(pluginFile)
-        val resolvedArtifact = runCatching { providers.getValue(config.provider).resolve(config) }.getOrNull()
-        val installed = artifactStateForInstalledFile(config, pluginFile, hash, resolvedArtifact)
+        val artifact = resolvedArtifact ?: runCatching { providers.getValue(config.provider).resolve(config) }.getOrNull()
+        val installed = artifactStateForInstalledFile(pluginFile, hash, artifact)
 
         states[config.id] = emptyState(config).copy(
             installed = installed,
@@ -515,8 +516,29 @@ object ExternalPluginManager {
         )
     }
 
+    private fun adoptMatchingInstalled(config: ExternalPluginConfig, pluginFile: File): ExternalPluginResult {
+        if (!pluginFile.isFile) return failure("${config.file} does not exist in ${relativePath(Constants.INSTALL_DIRECTORY)}")
+        if (!isJar(pluginFile)) return failure("${config.file} is not a valid JAR")
+
+        val artifact = runCatching { providers.getValue(config.provider).resolve(config) }.getOrElse { throwable ->
+            return failure("Could not verify existing ${config.id}: ${throwable.message ?: throwable::class.simpleName}")
+        }
+        val expectedHash = artifact.sha256
+            ?: return failure("${relativePath(pluginFile)} already exists; provider did not supply a SHA-256 digest, so use /pp external import to track it explicitly")
+        val actualHash = HashType.SHA256.hash(pluginFile)
+        if (!actualHash.equals(expectedHash, ignoreCase = true)) {
+            return failure("${relativePath(pluginFile)} already exists but does not match the latest provider artifact; remove it or use /pp external import to track the existing JAR")
+        }
+
+        return adoptInstalled(
+            config,
+            pluginFile,
+            "Imported existing ${config.id} from ${relativePath(pluginFile)}",
+            artifact
+        )
+    }
+
     private fun artifactStateForInstalledFile(
-        config: ExternalPluginConfig,
         pluginFile: File,
         hash: String,
         resolvedArtifact: ExternalArtifact?

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/ExternalPluginManager.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/ExternalPluginManager.kt
@@ -35,6 +35,8 @@ object ExternalPluginManager {
         GeyserExternalPluginProvider()
     ).associateBy(ExternalPluginProvider::id)
     private val pluginIdPattern = Regex("[A-Za-z0-9_-]+")
+    private val githubRepositoryPattern = Regex("[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+    private val geyserIdentifierPattern = Regex("[A-Za-z0-9_-]+")
     private val executor = Executors.newSingleThreadExecutor { runnable ->
         Thread(runnable, "PluginPortal-External").apply { isDaemon = true }
     }
@@ -98,7 +100,8 @@ object ExternalPluginManager {
             val source = section.getString("source").orEmpty().trim()
             val provider = source.substringBefore(':').lowercase()
             val sourceId = source.substringAfter(':', "").trim()
-            val file = section.getString("file").orEmpty().trim()
+            val file = section.getString("file")?.trim()?.takeIf(String::isNotEmpty)
+                ?: managedFileName(id, provider)
             val updatesValue = section.getString("updates", "manual").orEmpty()
             val updates = ExternalUpdatePolicy.from(updatesValue)
             val artifact = section.getString("artifact")?.trim()?.takeIf(String::isNotEmpty)
@@ -297,6 +300,38 @@ object ExternalPluginManager {
         .filter { currentState(it)?.installed != null }
         .map { update(it.id) }
 
+    @Synchronized
+    fun addGitHub(
+        id: String,
+        repository: String,
+        asset: String,
+        prereleases: Boolean
+    ): ExternalPluginResult = addConfig(gitHubConfig(id, repository, asset, managedFileName(id, "github"), prereleases))
+
+    @Synchronized
+    fun addGeyser(
+        id: String,
+        project: String,
+        artifact: String
+    ): ExternalPluginResult = addConfig(geyserConfig(id, project, artifact, managedFileName(id, "geysermc")))
+
+    @Synchronized
+    fun importGitHub(
+        id: String,
+        repository: String,
+        asset: String,
+        file: String,
+        prereleases: Boolean
+    ): ExternalPluginResult = importInstalled(gitHubConfig(id, repository, asset, file, prereleases))
+
+    @Synchronized
+    fun importGeyser(
+        id: String,
+        project: String,
+        artifact: String,
+        file: String
+    ): ExternalPluginResult = importInstalled(geyserConfig(id, project, artifact, file))
+
     private fun download(
         config: ExternalPluginConfig,
         destination: File,
@@ -382,6 +417,97 @@ object ExternalPluginManager {
         return failure("Could not download ${config.id}: $message$suffix")
     }
 
+    private fun addConfig(config: ExternalPluginConfig): ExternalPluginResult {
+        val validationError = validateConfig(config) ?: duplicateConfigError(config)
+        if (validationError != null) return failure(validationError)
+
+        writeConfig(config)
+        val errors = reload()
+        if (errors.isNotEmpty()) return failure("Configured ${config.id}, but external-plugins.yml has errors: ${errors.joinToString("; ")}")
+        return ExternalPluginResult(
+            success = true,
+            message = "Configured ${config.id} in external-plugins.yml as ${config.file}; run /pp external install ${config.id} to download it"
+        )
+    }
+
+    private fun gitHubConfig(
+        id: String,
+        repository: String,
+        asset: String,
+        file: String,
+        prereleases: Boolean
+    ) = ExternalPluginConfig(
+        id = id,
+        provider = "github",
+        sourceId = repository,
+        artifact = null,
+        asset = normalizeGitHubAssetPattern(asset),
+        file = file,
+        prereleases = prereleases,
+        updates = ExternalUpdatePolicy.MANUAL
+    )
+
+    private fun geyserConfig(
+        id: String,
+        project: String,
+        artifact: String,
+        file: String
+    ) = ExternalPluginConfig(
+        id = id,
+        provider = "geysermc",
+        sourceId = project,
+        artifact = artifact,
+        asset = null,
+        file = file,
+        prereleases = false,
+        updates = ExternalUpdatePolicy.MANUAL
+    )
+
+    private fun importInstalled(config: ExternalPluginConfig): ExternalPluginResult {
+        val validationError = validateConfig(config) ?: duplicateConfigError(config)
+        if (validationError != null) return failure(validationError)
+
+        val pluginFile = File(Constants.INSTALL_DIRECTORY, config.file)
+        if (!pluginFile.isFile) return failure("${config.file} does not exist in ${relativePath(Constants.INSTALL_DIRECTORY)}")
+        if (!isJar(pluginFile)) return failure("${config.file} is not a valid JAR")
+
+        val hash = HashType.SHA256.hash(pluginFile)
+        val resolvedArtifact = runCatching { providers.getValue(config.provider).resolve(config) }.getOrNull()
+        val installed = if (resolvedArtifact?.sha256?.equals(hash, ignoreCase = true) == true) {
+            ExternalArtifactState(
+                artifactId = resolvedArtifact.artifactId,
+                version = resolvedArtifact.version,
+                build = resolvedArtifact.build,
+                sha256 = hash,
+                recordedAt = Instant.now().toString()
+            )
+        } else {
+            ExternalArtifactState(
+                artifactId = "imported:${hash.take(12)}",
+                version = readPluginVersion(pluginFile) ?: "imported",
+                build = null,
+                sha256 = hash,
+                recordedAt = Instant.now().toString()
+            )
+        }
+
+        writeConfig(config)
+        val errors = reload()
+        if (errors.isNotEmpty()) return failure("Imported ${config.id}, but external-plugins.yml has errors: ${errors.joinToString("; ")}")
+
+        states[config.id] = emptyState(config).copy(
+            installed = installed,
+            lastCheckedAt = Instant.now().toString(),
+            lastError = null,
+            invalidated = false
+        )
+        saveState()
+        return ExternalPluginResult(
+            success = true,
+            message = "Imported ${config.id} from ${config.file}"
+        )
+    }
+
     private fun readState(): Map<String, ExternalPluginState> {
         if (!stateFile.exists()) return emptyMap()
         return try {
@@ -439,6 +565,45 @@ object ExternalPluginManager {
         configFingerprint = config.fingerprint()
     )
 
+    private fun validateConfig(config: ExternalPluginConfig): String? {
+        val invalidAssetRegex = config.provider == "github" &&
+            config.asset != null &&
+            runCatching { config.asset.toRegex() }.isFailure
+
+        return when {
+            !pluginIdPattern.matches(config.id) -> "${config.id}: plugin ID may only contain letters, numbers, underscores, and hyphens"
+            config.provider !in providers -> "${config.id}: unsupported source provider '${config.provider}'"
+            config.sourceId.isBlank() -> "${config.id}: source must not be blank"
+            config.provider == "github" && !githubRepositoryPattern.matches(config.sourceId) -> "${config.id}: GitHub source must use the owner/repository format"
+            config.provider == "geysermc" && !geyserIdentifierPattern.matches(config.sourceId) -> "${config.id}: invalid GeyserMC project name"
+            !isSafeJarName(config.file) -> "${config.id}: file must be a single .jar filename"
+            config.provider == "github" && config.asset.isNullOrBlank() -> "${config.id}: GitHub source requires an asset regex"
+            invalidAssetRegex -> "${config.id}: GitHub asset must be a valid regex"
+            config.provider == "geysermc" && config.artifact.isNullOrBlank() -> "${config.id}: GeyserMC source requires an artifact"
+            config.provider == "geysermc" && !geyserIdentifierPattern.matches(config.artifact.orEmpty()) -> "${config.id}: invalid GeyserMC artifact name"
+            else -> null
+        }
+    }
+
+    private fun duplicateConfigError(config: ExternalPluginConfig): String? {
+        if (config.id in configs) return "${config.id} is already configured"
+        val duplicateFile = configs.values.firstOrNull { it.file.equals(config.file, ignoreCase = true) }
+        return duplicateFile?.let { "${config.file} is already used by ${it.id}" }
+    }
+
+    private fun writeConfig(config: ExternalPluginConfig) {
+        if (!configFile.exists()) PluginPortalBase.plugin.saveResource("external-plugins.yml", false)
+        val yaml = YamlConfiguration.loadConfiguration(configFile).apply { options().pathSeparator('/') }
+        val path = "plugins/${config.id}"
+        yaml.set("$path/source", "${config.provider}:${config.sourceId}")
+        yaml.set("$path/artifact", config.artifact)
+        yaml.set("$path/asset", config.asset)
+        yaml.set("$path/file", config.file)
+        yaml.set("$path/prereleases", config.prereleases.takeIf { config.provider == "github" })
+        yaml.set("$path/updates", config.updates.name.lowercase())
+        yaml.save(configFile)
+    }
+
     private fun validateStateOwnership() {
         var stateChanged = false
 
@@ -495,6 +660,14 @@ object ExternalPluginManager {
         ZipFile(file).use { it.entries().hasMoreElements() }
     }.getOrDefault(false)
 
+    private fun readPluginVersion(file: File): String? = runCatching {
+        ZipFile(file).use { zip ->
+            val pluginYml = zip.getEntry("plugin.yml") ?: return@use null
+            val contents = zip.getInputStream(pluginYml).bufferedReader().use { it.readText() }
+            YamlConfiguration().apply { loadFromString(contents) }.getString("version")
+        }
+    }.getOrNull()
+
     private fun moveReplacing(source: File, destination: File) {
         runCatching {
             Files.move(
@@ -512,6 +685,19 @@ object ExternalPluginManager {
         val root = File(".").canonicalFile.toPath()
         val path = file.canonicalFile.toPath()
         return if (path.startsWith(root)) root.relativize(path).toString().replace(File.separatorChar, '/') else file.path
+    }
+
+    private fun managedFileName(id: String, provider: String): String {
+        val name = id.replace(Regex("[^A-Za-z0-9_.-]+"), "-").trim('-', '.', '_')
+            .takeIf(String::isNotBlank)
+            ?: "external"
+        return "[PP] $name [${provider.uppercase(Locale.ROOT)}].jar"
+    }
+
+    private fun normalizeGitHubAssetPattern(asset: String): String {
+        val trimmed = asset.trim()
+        val hasRegexSyntax = trimmed.any { it in "^$.*+?[](){}|\\" }
+        return if (hasRegexSyntax) trimmed else ".*${Regex.escape(trimmed)}.*\\.jar"
     }
 
     private fun failure(message: String) = ExternalPluginResult(false, message)

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/ExternalPluginManager.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/ExternalPluginManager.kt
@@ -160,6 +160,12 @@ object ExternalPluginManager {
         configs.values.sortedBy(ExternalPluginConfig::id).map { it to currentState(it) }
 
     @Synchronized
+    fun managedHashes(): Set<String> = states.values
+        .flatMap { state -> listOfNotNull(state.installed?.sha256, state.staged?.sha256) }
+        .map(String::lowercase)
+        .toSet()
+
+    @Synchronized
     fun verifyInstalledPluginStates() {
         var stateChanged = false
         val mismatchedIds = configs.values

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/ExternalPluginManager.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/ExternalPluginManager.kt
@@ -271,7 +271,7 @@ object ExternalPluginManager {
             if (destination.exists()) return failure("${config.id} is already installed; use external update")
             removeState(id)
         }
-        if (destination.exists()) return failure("${destination.path} already exists and is not tracked as an external plugin")
+        if (destination.exists()) return adoptInstalled(config, destination)
         return download(config, destination)
     }
 
@@ -483,29 +483,24 @@ object ExternalPluginManager {
         if (!pluginFile.isFile) return failure("${config.file} does not exist in ${relativePath(Constants.INSTALL_DIRECTORY)}")
         if (!isJar(pluginFile)) return failure("${config.file} is not a valid JAR")
 
-        val hash = HashType.SHA256.hash(pluginFile)
-        val resolvedArtifact = runCatching { providers.getValue(config.provider).resolve(config) }.getOrNull()
-        val installed = if (resolvedArtifact?.sha256?.equals(hash, ignoreCase = true) == true) {
-            ExternalArtifactState(
-                artifactId = resolvedArtifact.artifactId,
-                version = resolvedArtifact.version,
-                build = resolvedArtifact.build,
-                sha256 = hash,
-                recordedAt = Instant.now().toString()
-            )
-        } else {
-            ExternalArtifactState(
-                artifactId = "imported:${hash.take(12)}",
-                version = readPluginVersion(pluginFile) ?: "imported",
-                build = null,
-                sha256 = hash,
-                recordedAt = Instant.now().toString()
-            )
-        }
-
         writeConfig(config)
         val errors = reload()
         if (errors.isNotEmpty()) return failure("Imported ${config.id}, but external-plugins.yml has errors: ${errors.joinToString("; ")}")
+
+        return adoptInstalled(config, pluginFile, "Imported ${config.id} from ${config.file}")
+    }
+
+    private fun adoptInstalled(
+        config: ExternalPluginConfig,
+        pluginFile: File,
+        successMessage: String = "Imported existing ${config.id} from ${relativePath(pluginFile)}"
+    ): ExternalPluginResult {
+        if (!pluginFile.isFile) return failure("${config.file} does not exist in ${relativePath(Constants.INSTALL_DIRECTORY)}")
+        if (!isJar(pluginFile)) return failure("${config.file} is not a valid JAR")
+
+        val hash = HashType.SHA256.hash(pluginFile)
+        val resolvedArtifact = runCatching { providers.getValue(config.provider).resolve(config) }.getOrNull()
+        val installed = artifactStateForInstalledFile(config, pluginFile, hash, resolvedArtifact)
 
         states[config.id] = emptyState(config).copy(
             installed = installed,
@@ -516,7 +511,32 @@ object ExternalPluginManager {
         saveState()
         return ExternalPluginResult(
             success = true,
-            message = "Imported ${config.id} from ${config.file}"
+            message = successMessage
+        )
+    }
+
+    private fun artifactStateForInstalledFile(
+        config: ExternalPluginConfig,
+        pluginFile: File,
+        hash: String,
+        resolvedArtifact: ExternalArtifact?
+    ): ExternalArtifactState {
+        if (resolvedArtifact?.sha256?.equals(hash, ignoreCase = true) == true) {
+            return ExternalArtifactState(
+                artifactId = resolvedArtifact.artifactId,
+                version = resolvedArtifact.version,
+                build = resolvedArtifact.build,
+                sha256 = hash,
+                recordedAt = Instant.now().toString()
+            )
+        }
+
+        return ExternalArtifactState(
+            artifactId = "imported:${hash.take(12)}",
+            version = readPluginVersion(pluginFile) ?: "imported",
+            build = null,
+            sha256 = hash,
+            recordedAt = Instant.now().toString()
         )
     }
 

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/ExternalPluginManager.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/ExternalPluginManager.kt
@@ -101,7 +101,7 @@ object ExternalPluginManager {
             val provider = source.substringBefore(':').lowercase()
             val sourceId = source.substringAfter(':', "").trim()
             val file = section.getString("file")?.trim()?.takeIf(String::isNotEmpty)
-                ?: managedFileName(id, provider)
+                ?: managedExternalFileName(id, provider)
             val updatesValue = section.getString("updates", "manual").orEmpty()
             val updates = ExternalUpdatePolicy.from(updatesValue)
             val artifact = section.getString("artifact")?.trim()?.takeIf(String::isNotEmpty)
@@ -318,14 +318,14 @@ object ExternalPluginManager {
         repository: String,
         asset: String,
         prereleases: Boolean
-    ): ExternalPluginResult = addConfig(gitHubConfig(id, repository, asset, managedFileName(id, "github"), prereleases))
+    ): ExternalPluginResult = addConfig(gitHubConfig(id, repository, asset, managedExternalFileName(id, "github"), prereleases))
 
     @Synchronized
     fun addGeyser(
         id: String,
         project: String,
         artifact: String
-    ): ExternalPluginResult = addConfig(geyserConfig(id, project, artifact, managedFileName(id, "geysermc")))
+    ): ExternalPluginResult = addConfig(geyserConfig(id, project, artifact, managedExternalFileName(id, "geysermc")))
 
     @Synchronized
     fun importGitHub(
@@ -453,7 +453,7 @@ object ExternalPluginManager {
         provider = "github",
         sourceId = repository,
         artifact = null,
-        asset = normalizeGitHubAssetPattern(asset),
+        asset = normalizeExternalGitHubAssetPattern(asset),
         file = file,
         prereleases = prereleases,
         updates = ExternalUpdatePolicy.MANUAL
@@ -501,7 +501,7 @@ object ExternalPluginManager {
 
         val hash = HashType.SHA256.hash(pluginFile)
         val artifact = resolvedArtifact ?: runCatching { providers.getValue(config.provider).resolve(config) }.getOrNull()
-        val installed = artifactStateForInstalledFile(pluginFile, hash, artifact)
+        val installed = externalArtifactStateForInstalledFile(hash, readPluginVersion(pluginFile), artifact)
 
         states[config.id] = emptyState(config).copy(
             installed = installed,
@@ -535,30 +535,6 @@ object ExternalPluginManager {
             pluginFile,
             "Imported existing ${config.id} from ${relativePath(pluginFile)}",
             artifact
-        )
-    }
-
-    private fun artifactStateForInstalledFile(
-        pluginFile: File,
-        hash: String,
-        resolvedArtifact: ExternalArtifact?
-    ): ExternalArtifactState {
-        if (resolvedArtifact?.sha256?.equals(hash, ignoreCase = true) == true) {
-            return ExternalArtifactState(
-                artifactId = resolvedArtifact.artifactId,
-                version = resolvedArtifact.version,
-                build = resolvedArtifact.build,
-                sha256 = hash,
-                recordedAt = Instant.now().toString()
-            )
-        }
-
-        return ExternalArtifactState(
-            artifactId = "imported:${hash.take(12)}",
-            version = readPluginVersion(pluginFile) ?: "imported",
-            build = null,
-            sha256 = hash,
-            recordedAt = Instant.now().toString()
         )
     }
 
@@ -741,25 +717,50 @@ object ExternalPluginManager {
         return if (path.startsWith(root)) root.relativize(path).toString().replace(File.separatorChar, '/') else file.path
     }
 
-    private fun managedFileName(id: String, provider: String): String {
-        val name = id.replace(Regex("[^A-Za-z0-9_.-]+"), "-").trim('-', '.', '_')
-            .takeIf(String::isNotBlank)
-            ?: "external"
-        return "[PP] $name [${provider.uppercase(Locale.ROOT)}].jar"
-    }
-
-    private fun normalizeGitHubAssetPattern(asset: String): String {
-        val trimmed = asset.trim()
-        val hasRegexSyntax = trimmed.any { it in "^$.*+?[](){}|\\" }
-        return if (hasRegexSyntax) trimmed else ".*${Regex.escape(trimmed)}.*\\.jar"
-    }
-
     private fun failure(message: String) = ExternalPluginResult(false, message)
 
     private data class ExternalPluginStateFile(
         val plugins: Map<String, ExternalPluginState> = emptyMap()
     )
 
+}
+
+internal fun managedExternalFileName(id: String, provider: String): String {
+    val name = id.replace(Regex("[^A-Za-z0-9_.-]+"), "-").trim('-', '.', '_')
+        .takeIf(String::isNotBlank)
+        ?: "external"
+    return "[PP] $name [${provider.uppercase(Locale.ROOT)}].jar"
+}
+
+internal fun normalizeExternalGitHubAssetPattern(asset: String): String {
+    val trimmed = asset.trim()
+    val hasRegexSyntax = trimmed.any { it in "^$.*+?[](){}|\\" }
+    return if (hasRegexSyntax) trimmed else ".*${Regex.escape(trimmed)}.*\\.jar"
+}
+
+internal fun externalArtifactStateForInstalledFile(
+    hash: String,
+    installedVersion: String?,
+    resolvedArtifact: ExternalArtifact?,
+    recordedAt: String = Instant.now().toString()
+): ExternalArtifactState {
+    if (resolvedArtifact?.sha256?.equals(hash, ignoreCase = true) == true) {
+        return ExternalArtifactState(
+            artifactId = resolvedArtifact.artifactId,
+            version = resolvedArtifact.version,
+            build = resolvedArtifact.build,
+            sha256 = hash,
+            recordedAt = recordedAt
+        )
+    }
+
+    return ExternalArtifactState(
+        artifactId = "imported:${hash.take(12)}",
+        version = installedVersion ?: "imported",
+        build = null,
+        sha256 = hash,
+        recordedAt = recordedAt
+    )
 }
 
 data class ExternalPluginResult(

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/ExternalPluginManager.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/ExternalPluginManager.kt
@@ -160,9 +160,15 @@ object ExternalPluginManager {
         configs.values.sortedBy(ExternalPluginConfig::id).map { it to currentState(it) }
 
     @Synchronized
-    fun managedHashes(): Set<String> = states.values
+    fun managedHashes(): Set<String> = configs.keys
+        .mapNotNull(states::get)
         .flatMap { state -> listOfNotNull(state.installed?.sha256, state.staged?.sha256) }
         .map(String::lowercase)
+        .toSet()
+
+    @Synchronized
+    fun managedFileNames(): Set<String> = configs.values
+        .map { it.file.lowercase(Locale.ROOT) }
         .toSet()
 
     @Synchronized

--- a/common/src/test/kotlin/gg/flyte/pluginportal/common/managers/ExternalPluginManagerTest.kt
+++ b/common/src/test/kotlin/gg/flyte/pluginportal/common/managers/ExternalPluginManagerTest.kt
@@ -1,0 +1,69 @@
+package gg.flyte.pluginportal.common.managers
+
+import gg.flyte.pluginportal.common.adapters.external.ExternalArtifact
+import java.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ExternalPluginManagerTest {
+    @Test
+    fun `builds stable managed filenames`() {
+        assertEquals("[PP] viaversion [GITHUB].jar", managedExternalFileName("viaversion", "github"))
+        assertEquals("[PP] floodgate [GEYSERMC].jar", managedExternalFileName("floodgate", "geysermc"))
+    }
+
+    @Test
+    fun `turns a simple asset search into a jar regex`() {
+        val pattern = normalizeExternalGitHubAssetPattern("ViaVersion").toRegex()
+
+        assertTrue(pattern.matches("ViaVersion-5.4.2.jar"))
+    }
+
+    @Test
+    fun `preserves an explicit asset regex`() {
+        val pattern = "^ViaVersion-[0-9.]+\\.jar$"
+
+        assertEquals(pattern, normalizeExternalGitHubAssetPattern(pattern))
+    }
+
+    @Test
+    fun `uses verified provider metadata for a matching import`() {
+        val hash = "a".repeat(64)
+        val artifact = artifact(hash)
+
+        val state = externalArtifactStateForInstalledFile(hash, "local-version", artifact, RECORDED_AT)
+
+        assertEquals("asset-42", state.artifactId)
+        assertEquals("v5.4.2", state.version)
+        assertEquals(hash, state.sha256)
+    }
+
+    @Test
+    fun `does not claim provider metadata when an import cannot be verified`() {
+        val hash = "b".repeat(64)
+
+        val state = externalArtifactStateForInstalledFile(hash, "5.3.0", artifact(null), RECORDED_AT)
+
+        assertEquals("imported:${hash.take(12)}", state.artifactId)
+        assertEquals("5.3.0", state.version)
+        assertEquals(hash, state.sha256)
+    }
+
+    private fun artifact(hash: String?) = ExternalArtifact(
+        provider = "github",
+        sourceId = "ViaVersion/ViaVersion",
+        artifactId = "asset-42",
+        version = "v5.4.2",
+        build = null,
+        filename = "ViaVersion-5.4.2.jar",
+        downloadUrl = "https://example.com/ViaVersion-5.4.2.jar",
+        sha256 = hash,
+        publishedAt = Instant.parse("2026-07-15T00:00:00Z"),
+        changelog = null
+    )
+
+    private companion object {
+        const val RECORDED_AT = "2026-07-15T00:00:00Z"
+    }
+}

--- a/plugin/src/main/kotlin/gg/flyte/pluginportal/plugin/commands/ExternalSubCommand.kt
+++ b/plugin/src/main/kotlin/gg/flyte/pluginportal/plugin/commands/ExternalSubCommand.kt
@@ -7,11 +7,14 @@ import gg.flyte.pluginportal.common.commands.lamp.ExternalPluginSuggestionProvid
 import gg.flyte.pluginportal.common.managers.ExternalPluginManager
 import gg.flyte.pluginportal.common.managers.ExternalPluginResult
 import gg.flyte.pluginportal.plugin.commands.lamp.RequiresAuth
+import gg.flyte.pluginportal.plugin.commands.lamp.SafeFileName
 import net.kyori.adventure.audience.Audience
 import revxrsal.commands.annotation.Command
 import revxrsal.commands.annotation.Named
+import revxrsal.commands.annotation.Optional
 import revxrsal.commands.annotation.Subcommand
 import revxrsal.commands.annotation.SuggestWith
+import revxrsal.commands.annotation.Switch
 import revxrsal.commands.bukkit.annotation.CommandPermission
 
 @Command("pp", "pluginportal", "ppm")
@@ -30,6 +33,48 @@ class ExternalSubCommand {
         audience: Audience,
         @Named("id") @SuggestWith(ExternalPluginSuggestionProvider::class) id: String
     ) = runAsync(audience) { ExternalPluginManager.install(id) }
+
+    @RequiresAuth
+    @Subcommand("external add github")
+    fun addGitHub(
+        audience: Audience,
+        @Named("id") id: String,
+        @Named("owner") owner: String,
+        @Named("repository") repository: String,
+        @Named("asset") asset: String,
+        @Optional @Switch("prereleases") prereleases: Boolean = false
+    ) = runAsync(audience) { ExternalPluginManager.addGitHub(id, "$owner/$repository", asset, prereleases) }
+
+    @RequiresAuth
+    @Subcommand("external add geysermc")
+    fun addGeyser(
+        audience: Audience,
+        @Named("id") id: String,
+        @Named("project") project: String,
+        @Named("artifact") artifact: String
+    ) = runAsync(audience) { ExternalPluginManager.addGeyser(id, project, artifact) }
+
+    @RequiresAuth
+    @Subcommand("external import github")
+    fun importGitHub(
+        audience: Audience,
+        @Named("id") id: String,
+        @Named("owner") owner: String,
+        @Named("repository") repository: String,
+        @Named("asset") asset: String,
+        @Named("file") @SafeFileName file: String,
+        @Optional @Switch("prereleases") prereleases: Boolean = false
+    ) = runAsync(audience) { ExternalPluginManager.importGitHub(id, "$owner/$repository", asset, file, prereleases) }
+
+    @RequiresAuth
+    @Subcommand("external import geysermc")
+    fun importGeyser(
+        audience: Audience,
+        @Named("id") id: String,
+        @Named("project") project: String,
+        @Named("artifact") artifact: String,
+        @Named("file") @SafeFileName file: String
+    ) = runAsync(audience) { ExternalPluginManager.importGeyser(id, project, artifact, file) }
 
     @RequiresAuth
     @Subcommand("external update")

--- a/plugin/src/main/kotlin/gg/flyte/pluginportal/plugin/commands/lamp/PremiumSuggestionProviders.kt
+++ b/plugin/src/main/kotlin/gg/flyte/pluginportal/plugin/commands/lamp/PremiumSuggestionProviders.kt
@@ -1,6 +1,7 @@
 package gg.flyte.pluginportal.plugin.commands.lamp
 
 import gg.flyte.pluginportal.common.commands.lamp.CustomSuggestionProvider
+import gg.flyte.pluginportal.common.managers.ExternalPluginManager
 import gg.flyte.pluginportal.common.managers.LocalPluginCache
 import gg.flyte.pluginportal.common.util.HashType
 import gg.flyte.pluginportal.common.util.isJarFile
@@ -8,9 +9,19 @@ import gg.flyte.pluginportal.common.util.isPluginPortal
 import java.io.File
 
 class PluginJarFilesUnrecognisedSP: CustomSuggestionProvider({
+    val externalHashes = ExternalPluginManager.managedHashes()
+    val externalFileNames = ExternalPluginManager.managedFileNames()
     File("plugins").listFiles()
         .orEmpty()
-        .filter { it.isJarFile() && !LocalPluginCache.hasPluginByHash(HashType.SHA256.hash(it)) && !it.isPluginPortal }
+        .filter { file ->
+            if (!file.isJarFile()) return@filter false
+            val hash = runCatching { HashType.SHA256.hash(file) }.getOrNull() ?: return@filter false
+            !LocalPluginCache.hasPluginByHash(hash) &&
+                hash.lowercase() !in externalHashes &&
+                file.name.lowercase() !in externalFileNames &&
+                !LocalPluginCache.hasManagedDownloadedFile(file) &&
+                !file.isPluginPortal
+        }
         .map { it.name }
 })
 

--- a/plugin/src/main/kotlin/gg/flyte/pluginportal/plugin/commands/recognize/RecognizeAllSubCommand.kt
+++ b/plugin/src/main/kotlin/gg/flyte/pluginportal/plugin/commands/recognize/RecognizeAllSubCommand.kt
@@ -7,6 +7,7 @@ import gg.flyte.pluginportal.common.PlatformId
 import gg.flyte.pluginportal.common.chat.*
 import gg.flyte.pluginportal.common.commands.lamp.EnabledCommand
 import gg.flyte.pluginportal.common.commands.lamp.Features
+import gg.flyte.pluginportal.common.managers.ExternalPluginManager
 import gg.flyte.pluginportal.common.managers.LocalPluginCache
 import gg.flyte.pluginportal.common.managers.MarketplacePluginCache
 import gg.flyte.pluginportal.common.types.LocalPlugin
@@ -43,10 +44,16 @@ class RecognizeAllSubCommand {
     @CommandPermission("pluginportal.manage.recognize")
     fun recognizeAllCommand(audience: Audience) {
         async {
+            val externalHashes = ExternalPluginManager.managedHashes()
             val jars = Constants.INSTALL_DIRECTORY.listFiles()
                 ?.filter(File::isJarFile)
                 ?.associateBy(HashType.SHA256.hash)
-                ?.filter { !LocalPluginCache.hasPluginByHash(it.key) && !it.value.isPluginPortal && !LocalPluginCache.hasManagedDownloadedFile(it.value) }
+                ?.filter {
+                    !LocalPluginCache.hasPluginByHash(it.key) &&
+                        it.key.lowercase() !in externalHashes &&
+                        !it.value.isPluginPortal &&
+                        !LocalPluginCache.hasManagedDownloadedFile(it.value)
+                }
                 ?.map { RecognitionInfo(it.value, Recognize.getPolymartData(it.value)) }
                 ?.ifEmpty { return@async audience.sendSuccess("No plugins are unrecognized") }
                 ?: return@async audience.sendFailure("Could not determine a plugin directory")

--- a/plugin/src/main/kotlin/gg/flyte/pluginportal/plugin/commands/recognize/RecognizeAllSubCommand.kt
+++ b/plugin/src/main/kotlin/gg/flyte/pluginportal/plugin/commands/recognize/RecognizeAllSubCommand.kt
@@ -45,12 +45,14 @@ class RecognizeAllSubCommand {
     fun recognizeAllCommand(audience: Audience) {
         async {
             val externalHashes = ExternalPluginManager.managedHashes()
+            val externalFileNames = ExternalPluginManager.managedFileNames()
             val jars = Constants.INSTALL_DIRECTORY.listFiles()
                 ?.filter(File::isJarFile)
                 ?.associateBy(HashType.SHA256.hash)
                 ?.filter {
                     !LocalPluginCache.hasPluginByHash(it.key) &&
                         it.key.lowercase() !in externalHashes &&
+                        it.value.name.lowercase() !in externalFileNames &&
                         !it.value.isPluginPortal &&
                         !LocalPluginCache.hasManagedDownloadedFile(it.value)
                 }

--- a/plugin/src/main/kotlin/gg/flyte/pluginportal/plugin/commands/recognize/RecognizeSubCommand.kt
+++ b/plugin/src/main/kotlin/gg/flyte/pluginportal/plugin/commands/recognize/RecognizeSubCommand.kt
@@ -9,6 +9,7 @@ import gg.flyte.pluginportal.common.chat.sendInfo
 import gg.flyte.pluginportal.common.chat.sendSuccess
 import gg.flyte.pluginportal.common.commands.lamp.EnabledCommand
 import gg.flyte.pluginportal.common.commands.lamp.Features
+import gg.flyte.pluginportal.common.managers.ExternalPluginManager
 import gg.flyte.pluginportal.common.managers.LocalPluginCache
 import gg.flyte.pluginportal.common.managers.MarketplacePluginCache
 import gg.flyte.pluginportal.common.types.LocalPlugin
@@ -66,6 +67,10 @@ class RecognizeSubCommand {
             // Check if already installed
             if (LocalPluginCache.hasPluginByHash(sha256)) {
                 return@async audience.sendInfo("Plugin already installed")
+            }
+
+            if (sha256.lowercase() in ExternalPluginManager.managedHashes()) {
+                return@async audience.sendInfo("Plugin is already managed as an external plugin")
             }
 
             // Check for polymart.yml file in the jar

--- a/plugin/src/main/kotlin/gg/flyte/pluginportal/plugin/commands/recognize/RecognizeSubCommand.kt
+++ b/plugin/src/main/kotlin/gg/flyte/pluginportal/plugin/commands/recognize/RecognizeSubCommand.kt
@@ -69,7 +69,10 @@ class RecognizeSubCommand {
                 return@async audience.sendInfo("Plugin already installed")
             }
 
-            if (sha256.lowercase() in ExternalPluginManager.managedHashes()) {
+            if (
+                sha256.lowercase() in ExternalPluginManager.managedHashes() ||
+                pluginFile.name.lowercase() in ExternalPluginManager.managedFileNames()
+            ) {
                 return@async audience.sendInfo("Plugin is already managed as an external plugin")
             }
 

--- a/plugin/src/main/resources/external-plugins.yml
+++ b/plugin/src/main/resources/external-plugins.yml
@@ -4,12 +4,12 @@ plugins: {}
   # floodgate:
   #   source: geysermc:floodgate
   #   artifact: spigot
-  #   file: floodgate-spigot.jar
+  #   file: "[PP] floodgate [GEYSERMC].jar"
   #   updates: manual
 
   # viaversion:
   #   source: github:ViaVersion/ViaVersion
   #   asset: "^ViaVersion.*\\.jar$"
-  #   file: ViaVersion.jar
+  #   file: "[PP] viaversion [GITHUB].jar"
   #   prereleases: false
   #   updates: manual


### PR DESCRIPTION
Adds command-driven external plugin configuration/import, managed filenames, `/pp list --all`, and recognition exclusions for externally managed JARs.

Validation completed against the PR head and a synthetic merge with current `master`:
- `./gradlew clean test build`
- external-manager unit coverage for managed filenames, asset-pattern normalization, verified imports, and unverified import state
- `git diff --check`

This merge does not publish a Plugin Portal release.