### PR TITLE
Fix local testing, legacy cache migration, and plugin search

### DIFF
--- a/.agents/skills/plugin-portal-chat-capture/SKILL.md
+++ b/.agents/skills/plugin-portal-chat-capture/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: plugin-portal-chat-capture
+description: Capture real Plugin Portal command output with the repo's containerized MC Pilot client and share the Minecraft screenshot. Use for in-game chat review, command-output screenshots, and remote visual checks. Do not use a custom chat renderer when the native client can show the state.
+---
+
+# Plugin Portal chat capture
+
+Use the repository's MC Pilot container. It runs Paper 1.21.11 and a headless Fabric client named
+`Dawsson`; it does not need a host Minecraft login or a Devbox node.
+
+## Capture native chat
+
+Start or refresh the complete test environment from the repository root:
+
+```bash
+make mc-pilot-up
+```
+
+Run the requested command and take the screenshot. `mct chat command` accepts the command without
+the leading slash.
+
+```bash
+docker compose -f compose.mc-pilot.yml exec -T mc-pilot mct server exec op Dawsson
+docker compose -f compose.mc-pilot.yml exec -T mc-pilot mct chat clear
+docker compose -f compose.mc-pilot.yml exec -T mc-pilot mct chat command 'pp help'
+sleep 2
+docker compose -f compose.mc-pilot.yml exec -T mc-pilot \
+  mct screenshot --output /output/plugin-portal-chat.png
+```
+
+The host receives the image at `build/mc-pilot/plugin-portal-chat.png`. Inspect that file before
+sharing it. Keep captures under `build/mc-pilot`; build output is ignored and should not be committed.
+
+For another command, replace `pp help` and choose a descriptive output name. Prefer the native
+capture because it proves Minecraft's real font, wrapping, colors, hover layout, and spacing.
+
+## Share with Devbox files
+
+Upload from the local Mac. Supplying an explicit scope avoids requiring a `devbox.json` in this
+repository.
+
+```bash
+d files put build/mc-pilot/plugin-portal-chat.png \
+  --project plugin-portal \
+  --environment local-mac \
+  --ttl 30d \
+  --json
+```
+
+Do not print or read Devbox credentials. The CLI resolves its machine credential itself.
+
+If the installed `d` returns `INPUT_VALIDATION_FAILED` with `invalid_json`, it is using the old raw
+upload protocol. The current Devbox CLI source uses the JSON upload protocol expected by the API.
+Build it to a temporary directory and use that binary:
+
+```bash
+share_bin_dir="$(mktemp -d /tmp/plugin-portal-share.XXXXXX)"
+(cd /Users/dawson/projects/dawsson/devbox/go && go build -o "$share_bin_dir/d" .)
+"$share_bin_dir/d" files put \
+  /Users/dawson/projects/pp-v3/plugin-portal/build/mc-pilot/plugin-portal-chat.png \
+  --project plugin-portal \
+  --environment local-mac \
+  --ttl 30d \
+  --json
+```
+
+Treat the returned URL as authenticated until an anonymous request proves otherwise. As of
+2026-09-03, `/files/<id>` redirects anonymous visitors to Devbox login and the content route returns
+`401`. Say this plainly when the user asks for a public link. Do not claim that upload success proves
+anonymous access.
+
+Stop the environment only when the user is finished with it:
+
+```bash
+make mc-pilot-down
+```

--- a/.agents/skills/plugin-portal-chat-capture/agents/openai.yaml
+++ b/.agents/skills/plugin-portal-chat-capture/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Plugin Portal chat capture"
+  short_description: "Capture and share real Minecraft chat output"
+  default_prompt: "Capture the requested Plugin Portal command output in MC Pilot and share the screenshot."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,20 @@ Local development uses localhost only when the server starts with:
 
 ## Useful Commands
 
+The common development loop is available through `make`:
+
+```bash
+make test   # Fast MockBukkit checks
+make check  # Tests plus a complete build
+make smoke  # Disposable real-Paper install test
+make paper  # Reusable Paper server connected to the local API
+```
+
+`make paper` passes the localhost development flag automatically. It expects the API at
+`http://localhost:3001` and keeps its server files in `run/latest`.
+
+The underlying Gradle commands remain available when a more specific task is needed.
+
 Compile the plugin:
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+SHELL := /bin/sh
+
+.PHONY: help test check smoke paper
+
+help:
+	@echo "Plugin Portal commands:"
+	@echo "  make test   Run the fast MockBukkit test suite"
+	@echo "  make check  Run tests and build the plugin"
+	@echo "  make smoke  Test a real disposable Paper server and plugin install"
+	@echo "  make paper  Start a reusable Paper server against the local API"
+
+test:
+	./gradlew test
+
+check:
+	./gradlew clean test build
+
+smoke:
+	./gradlew test
+	./gradlew :plugin:paperSmoke
+
+paper:
+	./gradlew :plugin:runServer -PpluginPortalDev=true

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 SHELL := /bin/sh
 
-.PHONY: help test check smoke paper
+MC_PILOT_COMPOSE := docker compose -f compose.mc-pilot.yml
+PROJECT_VERSION := $(shell sed -n 's/^projectVersion=//p' gradle.properties)
+
+.PHONY: help test check smoke paper mc-pilot-plugin mc-pilot-up mc-pilot-shell mc-pilot-down
 
 help:
 	@echo "Plugin Portal commands:"
@@ -8,6 +11,9 @@ help:
 	@echo "  make check  Run tests and build the plugin"
 	@echo "  make smoke  Test a real disposable Paper server and plugin install"
 	@echo "  make paper  Start a reusable Paper server against the local API"
+	@echo "  make mc-pilot-up     Build and start the isolated MC Pilot container"
+	@echo "  make mc-pilot-shell  Open a shell in the MC Pilot container"
+	@echo "  make mc-pilot-down   Stop the MC Pilot container"
 
 test:
 	./gradlew test
@@ -21,3 +27,18 @@ smoke:
 
 paper:
 	./gradlew :plugin:runServer -PpluginPortalDev=true
+
+mc-pilot-plugin:
+	./gradlew :plugin:shadowJar
+	mkdir -p build/mc-pilot
+	cp out/PluginPortal-$(PROJECT_VERSION).jar build/mc-pilot/PluginPortal.jar
+
+mc-pilot-up: mc-pilot-plugin
+	$(MC_PILOT_COMPOSE) up -d --build
+	$(MC_PILOT_COMPOSE) exec -T mc-pilot mc-pilot-bootstrap
+
+mc-pilot-shell:
+	$(MC_PILOT_COMPOSE) exec mc-pilot sh
+
+mc-pilot-down:
+	$(MC_PILOT_COMPOSE) down

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ help:
 	@echo "  make check  Run tests and build the plugin"
 	@echo "  make smoke  Test a real disposable Paper server and plugin install"
 	@echo "  make paper  Start a reusable Paper server against the local API"
-	@echo "  make mc-pilot-up     Build and start the isolated MC Pilot container"
+	@echo "  make mc-pilot-up     Start the isolated MC Pilot test environment"
 	@echo "  make mc-pilot-shell  Open a shell in the MC Pilot container"
 	@echo "  make mc-pilot-down   Stop the MC Pilot container"
 
@@ -36,9 +36,11 @@ mc-pilot-plugin:
 mc-pilot-up: mc-pilot-plugin
 	$(MC_PILOT_COMPOSE) up -d --build
 	$(MC_PILOT_COMPOSE) exec -T mc-pilot mc-pilot-bootstrap
+	$(MC_PILOT_COMPOSE) exec -T mc-pilot sh -c 'mct down >/dev/null 2>&1 || true; mct up --eula'
 
 mc-pilot-shell:
 	$(MC_PILOT_COMPOSE) exec mc-pilot sh
 
 mc-pilot-down:
+	-$(MC_PILOT_COMPOSE) exec -T mc-pilot mct down
 	$(MC_PILOT_COMPOSE) down

--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ enforcement, not by a separate premium artifact.
 
 | Command | Permission | Description |
 | --- | --- | --- |
-| `/pp view <name \| id> [platform] [--byId] [--exact]` | `pluginportal.view` | View marketplace plugin details. |
-| `/pp install <name \| id> [platform] [channel] [--byId] [--exact] [--version <version>]` | `pluginportal.manage.install` | Install a plugin from a marketplace. |
-| `/pp update <name \| id> [--byId] [--channel <name>] [--version <version>]` | `pluginportal.maintain.update` | Update a tracked plugin. |
+| `/pp view <name\|id> [platform] [--byId] [--exact]` | `pluginportal.view` | View marketplace plugin details. |
+| `/pp install <name\|id> [platform] [channel] [--byId] [--exact] [--version <version>]` | `pluginportal.manage.install` | Install a plugin from a marketplace. |
+| `/pp update <name\|id> [--byId] [--channel <name>] [--version <version>]` | `pluginportal.maintain.update` | Update a tracked plugin. |
 | `/pp updateAll` | `pluginportal.maintain.update` | Update all tracked plugins with available updates. |
 | `/pp list [--all]` | `pluginportal.view` | List managed plugins; `--all` also shows unrecognized JARs. |
-| `/pp external <add \| import \| check \| install \| update \| invalidate \| updateAll \| reload>` | `pluginportal.manage.external` | Manage external plugins configured in `external-plugins.yml`. |
+| `/pp external <add\|import\|check\|install\|update\|invalidate\|updateAll\|reload>` | `pluginportal.manage.external` | Manage external plugins configured in `external-plugins.yml`. |
 | `/pp delete <name>` or `/pp uninstall <name>` | `pluginportal.manage.uninstall` | Remove a tracked plugin. |
 | `/pp recognize <file>` / `/pp recognizeAll` | `pluginportal.manage.recognize` | Track manually installed plugin JARs. |
 | `/pp upgrade [--yes]` | `pluginportal.admin` | Check for and install Plugin Portal updates. |

--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ enforcement, not by a separate premium artifact.
 
 | Command | Permission | Description |
 | --- | --- | --- |
-| `/pp view <name\|id> [platform] [--byId] [--exact]` | `pluginportal.view` | View marketplace plugin details. |
-| `/pp install <name\|id> [platform] [channel] [--byId] [--exact] [--version <version>]` | `pluginportal.manage.install` | Install a plugin from a marketplace. |
-| `/pp update <name\|id> [--byId] [--channel <name>] [--version <version>]` | `pluginportal.maintain.update` | Update a tracked plugin. |
+| `/pp view <name \| id> [platform] [--byId] [--exact]` | `pluginportal.view` | View marketplace plugin details. |
+| `/pp install <name \| id> [platform] [channel] [--byId] [--exact] [--version <version>]` | `pluginportal.manage.install` | Install a plugin from a marketplace. |
+| `/pp update <name \| id> [--byId] [--channel <name>] [--version <version>]` | `pluginportal.maintain.update` | Update a tracked plugin. |
 | `/pp updateAll` | `pluginportal.maintain.update` | Update all tracked plugins with available updates. |
 | `/pp list [--all]` | `pluginportal.view` | List managed plugins; `--all` also shows unrecognized JARs. |
-| `/pp external <add\|import\|check\|install\|update\|invalidate\|updateAll\|reload>` | `pluginportal.manage.external` | Manage external plugins configured in `external-plugins.yml`. |
+| `/pp external <add \| import \| check \| install \| update \| invalidate \| updateAll \| reload>` | `pluginportal.manage.external` | Manage external plugins configured in `external-plugins.yml`. |
 | `/pp delete <name>` or `/pp uninstall <name>` | `pluginportal.manage.uninstall` | Remove a tracked plugin. |
 | `/pp recognize <file>` / `/pp recognizeAll` | `pluginportal.manage.recognize` | Track manually installed plugin JARs. |
 | `/pp upgrade [--yes]` | `pluginportal.admin` | Check for and install Plugin Portal updates. |

--- a/buildSrc/src/main/kotlin/pp.plugin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/pp.plugin-conventions.gradle.kts
@@ -20,6 +20,9 @@ tasks {
     runServer {
         minecraftVersion("1.21.11")
         runDirectory(file((project.findProperty("runDir") as? String) ?: "run/latest"))
+        if ((project.findProperty("pluginPortalDev") as? String)?.toBoolean() == true) {
+            jvmArgs("-Dpluginportal.dev=true")
+        }
         javaLauncher.set(
             project.javaToolchains.launcherFor {
                 languageVersion.set(JavaLanguageVersion.of(21))

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/SearchPlugins.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/SearchPlugins.kt
@@ -2,6 +2,7 @@ package gg.flyte.pluginportal.common
 
 import com.google.common.cache.CacheBuilder
 import gg.flyte.pluginportal.common.types.Plugin
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 
 object SearchPlugins {
@@ -9,8 +10,16 @@ object SearchPlugins {
         .expireAfterWrite(1, TimeUnit.HOURS)
         .build<String, List<Plugin>>()
 
-    fun search(query: String): List<Plugin> {
-        return searchCache.get(query) { API.getPlugins(query)?.toList() ?: listOf() }
+    fun search(query: String): List<Plugin> = search(query) { API.getPlugins(it) }
+
+    internal fun search(query: String, fetch: (String) -> Array<Plugin>?): List<Plugin> {
+        return try {
+            searchCache.get(query) {
+                fetch(query)?.toList() ?: throw PluginSearchUnavailableException()
+            }
+        } catch (_: ExecutionException) {
+            emptyList()
+        }
     }
 
     fun getCachedSearch(query: String): List<Plugin>? {
@@ -19,3 +28,5 @@ object SearchPlugins {
             ?.value
     }
 }
+
+private class PluginSearchUnavailableException : Exception()

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/chat/ChatUtil.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/chat/ChatUtil.kt
@@ -74,6 +74,9 @@ fun Audience.sendFailure(msg: String) = send(Status.FAILURE, msg)
 fun Audience.sendInfo(msg: String) = send(Status.INFO, msg)
 fun Audience.sendSuccess(msg: String) = send(Status.SUCCESS, msg)
 
+fun progress(action: String, target: String): Component =
+    textSecondary("$action ").appendPrimary(target).appendSecondary("...")
+
 fun Audience.sendUnAuthed() = sendMessage(
     status(Status.FAILURE, "You are not authenticated. ")
         .appendSecondary("Join our ")
@@ -115,7 +118,7 @@ fun sendPluginListMessage(audience: Audience, message: String, plugins: List<Plu
             }
         }
 
-        val platform = plugin.bestPlatform ?: return audience.sendFailure("Can't find a platform to pull information from")
+        val platform = plugin.bestPlatform ?: return@forEach
         val name = plugin.name.shortenToLine(
             23 + plugin.totalDownloads.format().pixelLength() + plugin.platformString.pixelLength()
         )

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/HelpSubCommand.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/HelpSubCommand.kt
@@ -75,12 +75,12 @@ class HelpSubCommand {
                     "Example: /pp platform essentialsx modrinth"
                 )))
                 .appendNewline()
-                .append(helpLine("/pp <uninstall|delete> <plugin>", "Remove", details = listOf(
+                .append(helpLine("/pp <uninstall | delete> <plugin>", "Remove", details = listOf(
                     "Flags: --byId",
                     "Example: /pp uninstall luckperms"
                 )))
                 .appendNewline()
-                .append(helpLine("/pp <version|info>", "Status"))
+                .append(helpLine("/pp <version | info>", "Status"))
                 .appendNewline()
                 .appendNewline()
                 .append(footer(2))
@@ -91,7 +91,7 @@ class HelpSubCommand {
                     "Example: /pp install-url https://example.com/plugin.jar"
                 )))
                 .appendNewline()
-                .append(helpLine("/pp key <set|get|clear>", "API key", details = listOf(
+                .append(helpLine("/pp key <set | get | clear>", "API key", details = listOf(
                     "Example: /pp key set pp_live_..."
                 )))
                 .appendNewline()
@@ -133,7 +133,7 @@ class HelpSubCommand {
             .appendNewline()
             .append(section("Premium", gold))
             .appendNewline()
-            .append(helpLine("/pp editor [status|url|reconnect|stop]", "Editor", gold, listOf(
+            .append(helpLine("/pp editor [status | url | reconnect | stop]", "Editor", gold, listOf(
                 "Creates a temporary browser editor session.",
                 "Example: /pp editor url"
             )))
@@ -149,7 +149,7 @@ class HelpSubCommand {
             .appendNewline()
             .append(helpLine("/pp recognizeAll", "Recognize all", gold))
             .appendNewline()
-            .append(helpLine("/pp <import|export>", "Import/export", gold, listOf(
+            .append(helpLine("/pp <import | export>", "Import/export", gold, listOf(
                 "Import requires an MCLogs URL created by /pp export.",
                 "Example: /pp import https://mclo.gs/abc123"
             )))

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/InstallSubCommand.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/InstallSubCommand.kt
@@ -10,6 +10,7 @@ import gg.flyte.pluginportal.common.commands.lamp.EnabledCommand
 import gg.flyte.pluginportal.common.commands.lamp.Features
 import gg.flyte.pluginportal.common.commands.lamp.MarketplacePluginSuggestionProvider
 import gg.flyte.pluginportal.common.commands.lamp.ReleaseChannelSuggestionProvider
+import gg.flyte.pluginportal.common.managers.LocalPluginCache
 import gg.flyte.pluginportal.common.managers.MarketplacePluginCache
 import gg.flyte.pluginportal.common.types.ExactVersionSelection
 import gg.flyte.pluginportal.common.types.exactCompatibleVersionWithFallback
@@ -49,8 +50,12 @@ class InstallSubCommand {
             byId,
             exact = exact,
             ifSingle = { plugin ->
-                audience.sendMessage(startLine().appendSecondary("Starting installation of ").appendPrimary(plugin.name).appendSecondary("...").appendNewline())
                 async {
+                    if (LocalPluginCache.hasPlugin(plugin)) {
+                        audience.sendInfo("${plugin.name} is already installed.")
+                        return@async
+                    }
+
 //                    val request = DownloadRequest(
 //                        plugin = plugin,
 //                        targetDirectory = File("plugins"),
@@ -100,6 +105,8 @@ class InstallSubCommand {
                         return@async
                     }
 
+                    audience.sendMessage(progress("Installing", plugin.name))
+
                     val newPlugin = plugin.download(
                         update = false,
                         marketplacePlatform = targetPlatform.platform,
@@ -114,11 +121,6 @@ class InstallSubCommand {
                     if (newPlugin != null) {
                         audience.sendMessage(SharedComponents.successfullyInstalledPlugin(plugin.name, newPlugin.platform))
                         if (exactVersionNumber != null) audience.sendInfo("${plugin.name} is excluded from updateAll because you installed a specific version.")
-                    } else {
-                        // Send this as any failure would have been of itself, boxed.
-                        audience.sendMessage(endLine())
-                        // This should be handled already
-//                        audience.sendFailure("Installation failed when attempting to install ${plugin.name} (${plugin.id})")
                     }
                 }
             },

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/UpdateSubCommand.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/UpdateSubCommand.kt
@@ -105,7 +105,7 @@ class UpdateSubCommand {
             return audience.sendSuccess("Plugin is already up to date")
         }
 
-        audience.sendMessage(startLine().appendSecondary("Starting update of ").appendPrimary(localPlugin.name).appendSecondary("...").appendNewline())
+        audience.sendMessage(progress("Updating", localPlugin.name))
 
         val targetPlatform = localPlugin.platform
         val targetMessage = "${localPlugin.name} from $targetPlatform with ID ${localPlugin.platformId}"

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/lamp/SuggestionProviders.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/lamp/SuggestionProviders.kt
@@ -8,29 +8,32 @@ import gg.flyte.pluginportal.common.managers.MarketplacePluginCache
 import gg.flyte.pluginportal.common.types.LocalPlugin
 import gg.flyte.pluginportal.common.types.Plugin
 import gg.flyte.pluginportal.common.types.enums.MarketplacePlatform
-import gg.flyte.pluginportal.common.util.async
+import revxrsal.commands.autocomplete.AsyncSuggestionProvider
 import revxrsal.commands.autocomplete.SuggestionProvider
 import revxrsal.commands.bukkit.actor.BukkitCommandActor
 import revxrsal.commands.node.ExecutionContext
 import revxrsal.commands.stream.StringStream
+import java.util.concurrent.CompletableFuture
 
 abstract class CustomSuggestionProvider(val suggestions: (ExecutionContext<BukkitCommandActor>) -> List<String>): SuggestionProvider<BukkitCommandActor> {
     override fun getSuggestions(context: ExecutionContext<BukkitCommandActor>) = suggestions(context)
 }
 
-class MarketplacePluginSuggestionProvider: CustomSuggestionProvider({
-    val searchName = it.input().toArgs().last()
-    if (searchName.length == 2) async { SearchPlugins.search(searchName) }
-    if (searchName.length <= 2)
-        listOf("Keep typing...")
-    else {
-        SearchPlugins.getCachedSearch(searchName)
-            ?.map(Plugin::name)
-            ?.filter { it.startsWith(searchName, true) }
-            ?.map { "\"$it\"" }
-            ?: listOf("Loading...")
+class MarketplacePluginSuggestionProvider : AsyncSuggestionProvider<BukkitCommandActor> {
+    override fun getSuggestionsAsync(context: ExecutionContext<BukkitCommandActor>): CompletableFuture<Collection<String>> {
+        val searchName = context.input().toArgs().last()
+        if (searchName.length <= 2) {
+            return CompletableFuture.completedFuture(listOf("Keep typing..."))
+        }
+
+        return CompletableFuture.supplyAsync {
+            SearchPlugins.search(searchName.take(3))
+                .map(Plugin::name)
+                .filter { it.startsWith(searchName, true) }
+                .map { "\"$it\"" }
+        }
     }
-})
+}
 
 class InstalledPluginSuggestionProvider: CustomSuggestionProvider({
     LocalPluginCache.map { "\"${it.name}\"" }

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/LocalPluginCache.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/LocalPluginCache.kt
@@ -36,7 +36,7 @@ object LocalPluginCache : PluginCache<LocalPlugin>() {
 
     fun getAllPluginsAsPlatformIds() = map { PlatformId(it.platformId, it.platform) }
     fun getEntryIdMap(): EntryIdMap = groupBy { it.platform }
-        .mapValues { it.value.map(LocalPlugin::entryId) }
+        .mapValues { (_, plugins) -> plugins.filter(LocalPlugin::hasResolvedEntryId).map(LocalPlugin::entryId) }
         .let { EntryIdMap(it[MODRINTH] ?: listOf(), it[HANGAR] ?: listOf(), it[SPIGOTMC] ?: listOf(), it[POLYMART] ?: listOf()) }
 
     fun reloadCache() {
@@ -45,8 +45,9 @@ object LocalPluginCache : PluginCache<LocalPlugin>() {
 
         try {
             clear()
-            val plugins = GSON.fromJson(text, Array<LocalPlugin>::class.java)
-            addAll(plugins)
+            val migration = readPlugins(text)
+            addAll(migration.plugins)
+            if (migration.migratedCount > 0) save()
 
         } catch (_: JsonSyntaxException) {
         }
@@ -80,7 +81,8 @@ object LocalPluginCache : PluginCache<LocalPlugin>() {
         }
 
         try {
-            val plugins = GSON.fromJson(text, Array<LocalPlugin>::class.java)
+            val migration = readPlugins(text)
+            val plugins = migration.plugins
 
             plugins.forEach { plugin ->
                 // Update Plugin Portal's own local cache entry.
@@ -102,6 +104,29 @@ object LocalPluginCache : PluginCache<LocalPlugin>() {
             PortalLogger.info(PortalLogger.Action.LOAD_PLUGINS, "Loaded ${plugins.size} plugins from local cache")
         } catch (_: JsonSyntaxException) {
         }
+    }
+
+    private fun readPlugins(text: String): LocalPluginCacheMigrationResult {
+        val migration = migrateLocalPluginCache(text) { platformIds ->
+            val pluginsByPlatform = API.getAllPluginsByPlatformIds(platformIds) ?: return@migrateLocalPluginCache emptyMap()
+            platformIds.mapNotNull { identity ->
+                val entryId = pluginsByPlatform[identity.platform]
+                    ?.get(identity.platformId)
+                    ?.platform(identity.platform)
+                    ?.entryId
+                entryId?.let { identity to it }
+            }.toMap()
+        }
+
+        if (migration.migratedCount > 0) {
+            PluginPortalBase.plugin.logger.info("Migrated ${migration.migratedCount} legacy Plugin Portal cache entries.")
+        }
+        if (migration.unresolvedCount > 0) {
+            PluginPortalBase.plugin.logger.warning(
+                "Could not resolve ${migration.unresolvedCount} legacy cache entry IDs; retained those plugins and will retry later."
+            )
+        }
+        return migration
     }
 
     fun save() {

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/LocalPluginCacheMigration.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/LocalPluginCacheMigration.kt
@@ -1,0 +1,72 @@
+package gg.flyte.pluginportal.common.managers
+
+import gg.flyte.pluginportal.common.PlatformId
+import gg.flyte.pluginportal.common.types.LocalPlugin
+import gg.flyte.pluginportal.common.types.enums.MarketplacePlatform
+import gg.flyte.pluginportal.common.util.GSON
+
+internal const val LEGACY_ENTRY_ID_PREFIX = "legacy:"
+
+internal data class LocalPluginCacheMigrationResult(
+    val plugins: List<LocalPlugin>,
+    val migratedCount: Int,
+    val unresolvedCount: Int,
+)
+
+private data class StoredLocalPlugin(
+    val entryId: String? = null,
+    val platformId: String,
+    val name: String,
+    val version: String,
+    val platform: MarketplacePlatform,
+    val sha256: String,
+    val sha512: String,
+    val installedAt: Long,
+    val preferredChannel: String? = null,
+    val excludedFromUpdates: Boolean = false,
+)
+
+internal fun migrateLocalPluginCache(
+    text: String,
+    resolveEntryIds: (List<PlatformId>) -> Map<PlatformId, String>,
+): LocalPluginCacheMigrationResult {
+    val storedPlugins = GSON.fromJson(text, Array<StoredLocalPlugin>::class.java).toList()
+    val identitiesToResolve = storedPlugins
+        .filter { it.entryId.isNullOrBlank() || it.entryId.startsWith(LEGACY_ENTRY_ID_PREFIX) }
+        .map { PlatformId(it.platformId, it.platform) }
+        .distinct()
+    val resolvedEntryIds = if (identitiesToResolve.isEmpty()) emptyMap() else resolveEntryIds(identitiesToResolve)
+
+    var migratedCount = 0
+    var unresolvedCount = 0
+    val plugins = storedPlugins.map { stored ->
+        val identity = PlatformId(stored.platformId, stored.platform)
+        val existingEntryId = stored.entryId
+            ?.takeIf(String::isNotBlank)
+            ?.takeUnless { it.startsWith(LEGACY_ENTRY_ID_PREFIX) }
+        val entryId = existingEntryId
+            ?: resolvedEntryIds[identity]?.takeIf(String::isNotBlank)
+            ?: "$LEGACY_ENTRY_ID_PREFIX${stored.platform.name.lowercase()}:${stored.platformId}".also {
+                unresolvedCount++
+            }
+
+        if (entryId != stored.entryId) migratedCount++
+        LocalPlugin(
+            entryId = entryId,
+            platformId = stored.platformId,
+            name = stored.name,
+            version = stored.version,
+            platform = stored.platform,
+            sha256 = stored.sha256,
+            sha512 = stored.sha512,
+            installedAt = stored.installedAt,
+            preferredChannel = stored.preferredChannel,
+            excludedFromUpdates = stored.excludedFromUpdates,
+        )
+    }
+
+    return LocalPluginCacheMigrationResult(plugins, migratedCount, unresolvedCount)
+}
+
+internal fun LocalPlugin.hasResolvedEntryId(): Boolean =
+    entryId.isNotBlank() && !entryId.startsWith(LEGACY_ENTRY_ID_PREFIX)

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/MarketplacePluginCache.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/MarketplacePluginCache.kt
@@ -117,6 +117,8 @@ object MarketplacePluginCache: PluginCache<Plugin>() {
                 var plugins = getFilteredPlugins(name, platform)
                 if (exact) {
                     plugins = plugins.filter { it.name.equals(name, true) }
+                } else {
+                    plugins = plugins.preferUniqueExactName(name)
                 }
                 when {
                     plugins.isEmpty() -> audience.sendFailure("No plugins found")
@@ -188,6 +190,11 @@ object MarketplacePluginCache: PluginCache<Plugin>() {
      */
     fun List<Plugin>.sortedByRelevance(query: String): List<Plugin> = sortedByDescending {
         it.totalDownloads * if (query.equals(it.name, true)) 50 else 1 // Arbitrary bias to exact matches
+    }
+
+    internal fun List<Plugin>.preferUniqueExactName(query: String): List<Plugin> {
+        val exactMatches = filter { it.name.equals(query, ignoreCase = true) }
+        return if (exactMatches.size == 1) exactMatches else this
     }
 
     private fun String.normalizedLookup(): String =

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/util/SharedComponents.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/util/SharedComponents.kt
@@ -21,7 +21,7 @@ object SharedComponents {
     fun successfullyInstalledPlugin(pluginName: String, platform: MarketplacePlatform, plsrestart: Boolean = true) =
         status(Status.SUCCESS, "Downloaded $pluginName from ${platform.name}.")
             .also { if (plsrestart) it.appendSecondary("\n- Please restart your server to enable this plugin") }
-            .append(endLine())
+            .boxed()
 
     fun getUpdateBeforeAndAfterComponent(plugin: LocalPlugin, new: Plugin) = Component.text(
         "(",

--- a/common/src/test/kotlin/gg/flyte/pluginportal/common/SearchPluginsTest.kt
+++ b/common/src/test/kotlin/gg/flyte/pluginportal/common/SearchPluginsTest.kt
@@ -1,0 +1,35 @@
+package gg.flyte.pluginportal.common
+
+import gg.flyte.pluginportal.common.types.Platforms
+import gg.flyte.pluginportal.common.types.Plugin
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.util.Date
+
+class SearchPluginsTest {
+    @Test
+    fun `failed searches can be retried`() {
+        val plugin = Plugin(
+            id = "viaversion-test",
+            name = "ViaVersion",
+            totalDownloads = 0,
+            platforms = Platforms(null, null, null, null),
+            createdAt = Date(0),
+            updatedAt = Date(0)
+        )
+        var attempts = 0
+
+        val failed = SearchPlugins.search("retryable-search") {
+            attempts++
+            null
+        }
+        val retried = SearchPlugins.search("retryable-search") {
+            attempts++
+            arrayOf(plugin)
+        }
+
+        assertEquals(emptyList<Plugin>(), failed)
+        assertEquals(listOf(plugin), retried)
+        assertEquals(2, attempts)
+    }
+}

--- a/common/src/test/kotlin/gg/flyte/pluginportal/common/managers/LocalPluginCacheMigrationTest.kt
+++ b/common/src/test/kotlin/gg/flyte/pluginportal/common/managers/LocalPluginCacheMigrationTest.kt
@@ -1,0 +1,49 @@
+package gg.flyte.pluginportal.common.managers
+
+import gg.flyte.pluginportal.common.PlatformId
+import gg.flyte.pluginportal.common.types.enums.MarketplacePlatform.HANGAR
+import gg.flyte.pluginportal.common.types.enums.MarketplacePlatform.MODRINTH
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class LocalPluginCacheMigrationTest {
+    @Test
+    fun `legacy cache entries survive startup and gain stable entry ids`() {
+        val legacyCache = """
+            [
+              {
+                "platformId": "3wmN97b8",
+                "name": "Multiverse-Core",
+                "version": "5.6.2",
+                "platform": "MODRINTH",
+                "sha256": "multiverse-sha256",
+                "sha512": "multiverse-sha512",
+                "installedAt": 1779562612528
+              },
+              {
+                "platformId": "ViaVersion",
+                "name": "ViaVersion",
+                "version": "5.9.2-SNAPSHOT+996",
+                "platform": "HANGAR",
+                "sha256": "viaversion-sha256",
+                "sha512": "viaversion-sha512",
+                "installedAt": 1779563017721
+              }
+            ]
+        """.trimIndent()
+
+        val result = migrateLocalPluginCache(legacyCache) { identities ->
+            assertEquals(listOf(PlatformId("3wmN97b8", MODRINTH), PlatformId("ViaVersion", HANGAR)), identities)
+            mapOf(PlatformId("3wmN97b8", MODRINTH) to "resolved-multiverse-entry")
+        }
+
+        assertEquals(2, result.migratedCount)
+        assertEquals(1, result.unresolvedCount)
+        assertEquals("resolved-multiverse-entry", result.plugins[0].entryId)
+        assertEquals("legacy:hangar:ViaVersion", result.plugins[1].entryId)
+        assertEquals(2, result.plugins.toMutableSet().size)
+        assertTrue(result.plugins[0].hasResolvedEntryId())
+        assertTrue(!result.plugins[1].hasResolvedEntryId())
+    }
+}

--- a/common/src/test/kotlin/gg/flyte/pluginportal/common/managers/MarketplacePluginCacheTest.kt
+++ b/common/src/test/kotlin/gg/flyte/pluginportal/common/managers/MarketplacePluginCacheTest.kt
@@ -1,0 +1,43 @@
+package gg.flyte.pluginportal.common.managers
+
+import gg.flyte.pluginportal.common.types.Platforms
+import gg.flyte.pluginportal.common.types.Plugin
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.util.Date
+
+class MarketplacePluginCacheTest {
+    @Test
+    fun `a unique exact name wins over related prefix matches`() {
+        val exact = plugin("ViaVersion")
+        val related = plugin("ViaVersionStatus")
+
+        val selected = with(MarketplacePluginCache) {
+            listOf(related, exact).preferUniqueExactName("viaversion")
+        }
+
+        assertEquals(listOf(exact), selected)
+    }
+
+    @Test
+    fun `duplicate exact names still require disambiguation`() {
+        val first = plugin("ViaVersion")
+        val second = plugin("viaversion")
+        val matches = listOf(first, second)
+
+        val selected = with(MarketplacePluginCache) {
+            matches.preferUniqueExactName("ViaVersion")
+        }
+
+        assertEquals(matches, selected)
+    }
+
+    private fun plugin(name: String) = Plugin(
+        id = name,
+        name = name,
+        totalDownloads = 0,
+        platforms = Platforms(null, null, null, null),
+        createdAt = Date(0),
+        updatedAt = Date(0)
+    )
+}

--- a/compose.mc-pilot.yml
+++ b/compose.mc-pilot.yml
@@ -1,0 +1,24 @@
+services:
+  mc-pilot:
+    platform: linux/amd64
+    build:
+      context: docker/mc-pilot
+      args:
+        MC_PILOT_COMMIT: 561b15c79894672f4b046aadf93bbdb70d61c34b
+    init: true
+    working_dir: /workspace
+    environment:
+      DISPLAY: :99
+      MCT_SKILL_TARGETS: none
+    volumes:
+      - .:/workspace:ro
+      - ./build/mc-pilot:/output
+      - mc-pilot-state:/home/node/.mct
+    shm_size: 1gb
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+
+volumes:
+  mc-pilot-state:

--- a/docker/mc-pilot/Dockerfile
+++ b/docker/mc-pilot/Dockerfile
@@ -1,0 +1,53 @@
+FROM node:24-trixie-slim
+
+ARG MC_PILOT_COMMIT
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        libasound2t64 \
+        libfontconfig1 \
+        libfreetype6 \
+        libgl1 \
+        libgl1-mesa-dri \
+        libgtk-3-0 \
+        libx11-6 \
+        libxcursor1 \
+        libxext6 \
+        libxi6 \
+        libxinerama1 \
+        libxrandr2 \
+        libxrender1 \
+        libxtst6 \
+        openjdk-21-jdk-headless \
+        xauth \
+        xvfb \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/kzheart/mc-pilot.git /opt/mc-pilot \
+    && cd /opt/mc-pilot \
+    && git checkout --detach "$MC_PILOT_COMMIT" \
+    && test "$(git rev-parse HEAD)" = "$MC_PILOT_COMMIT" \
+    && npm ci --ignore-scripts \
+    && npm run build \
+    && rm -rf /root/.gradle /root/.npm /opt/mc-pilot/.git
+
+RUN ln -s /opt/mc-pilot/cli/bin/mct /usr/local/bin/mct \
+    && chmod +x /opt/mc-pilot/cli/bin/mct \
+    && mkdir -p /home/node/.mct \
+    && chown node:node /home/node/.mct
+
+COPY bootstrap.sh entrypoint.sh /usr/local/bin/
+
+RUN chmod +x /usr/local/bin/bootstrap.sh /usr/local/bin/entrypoint.sh \
+    && ln -s /usr/local/bin/bootstrap.sh /usr/local/bin/mc-pilot-bootstrap \
+    && ln -s /usr/local/bin/entrypoint.sh /usr/local/bin/mc-pilot-entrypoint
+
+USER node
+WORKDIR /workspace
+ENV DISPLAY=:99 \
+    MCT_SKILL_TARGETS=none
+
+ENTRYPOINT ["mc-pilot-entrypoint"]
+CMD ["sleep", "infinity"]

--- a/docker/mc-pilot/bootstrap.sh
+++ b/docker/mc-pilot/bootstrap.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -eu
+
+project_dir=/home/node/.mct/projects/-workspace
+
+if [ ! -f "$project_dir/project.json" ]; then
+  mct init --name plugin-portal >/dev/null
+fi
+
+if [ ! -f "$project_dir/paper-1.21.11/instance.json" ]; then
+  mct server create paper-1.21.11 --type paper --version 1.21.11 --eula >/dev/null
+fi
+
+if [ ! -f /home/node/.mct/clients/fabric-1.21.11/instance.json ]; then
+  mct client create fabric-1.21.11 \
+    --version 1.21.11 \
+    --loader fabric \
+    --account Dawsson \
+    --headless >/dev/null
+fi
+
+node -e '
+const fs = require("node:fs");
+const path = "/home/node/.mct/projects/-workspace/project.json";
+const project = JSON.parse(fs.readFileSync(path, "utf8"));
+project.defaultProfile = "1.21.11";
+project.profiles["1.21.11"] = {
+  server: "paper-1.21.11",
+  clients: ["fabric-1.21.11"],
+  deployPlugins: ["/output/PluginPortal.jar"]
+};
+project.screenshot.outputDir = "/output";
+fs.writeFileSync(path, `${JSON.stringify(project, null, 2)}\n`);
+'
+
+echo "MC Pilot is ready. Run 'make mc-pilot-shell', then 'mct up --eula'."

--- a/docker/mc-pilot/bootstrap.sh
+++ b/docker/mc-pilot/bootstrap.sh
@@ -33,4 +33,4 @@ project.screenshot.outputDir = "/output";
 fs.writeFileSync(path, `${JSON.stringify(project, null, 2)}\n`);
 '
 
-echo "MC Pilot is ready. Run 'make mc-pilot-shell', then 'mct up --eula'."
+echo "MC Pilot is configured."

--- a/docker/mc-pilot/entrypoint.sh
+++ b/docker/mc-pilot/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+Xvfb "$DISPLAY" -screen 0 1280x720x24 -nolisten tcp >/tmp/xvfb.log 2>&1 &
+
+exec "$@"


### PR DESCRIPTION
## Summary
- add small `make` entry points for fast checks, full builds, real-Paper smoke testing, and interactive Paper development
- pass the localhost-only API flag to the interactive Paper task
- migrate legacy `plugins.json` rows that predate `entryId` without crashing server startup
- resolve missing IDs in one batch when possible and retain stable retryable placeholders when the API is unavailable
- exclude unresolved placeholders from entry-ID cache refreshes while preserving platform-ID update lookups
- use Lamp async completion futures for marketplace searches instead of exposing a permanent `Loading...` suggestion
- leave failed marketplace searches uncached so a recovered API can be retried
- prefer a unique exact plugin name over related prefix matches
- make install/update progress compact and final status components self-contained
- treat an already-installed plugin as an informational no-op before version lookup or progress output
- consistently space command alternatives around `|` in the in-game help

## Verification
- `make test`
- `make check`
- `./gradlew :common:test :plugin:test`
- focused regression tests for retrying failed marketplace searches, exact-name selection versus related results, duplicate-name disambiguation, and legacy cache migration
- live Paper 1.21.11 upgrade using the original legacy cache: migrated both rows, enabled PluginPortal, and reached `Done` without the prior `LocalPlugin.hashCode` exception
- live Paper 1.21.11 command checks against the production API: spaced in-game help rendered, ViaVersion suggestions resolved, `/pp install ViaVersion` selected ViaVersion rather than related plugins, and both name and Modrinth-ID installs returned one compact already-installed info result
- `make smoke` (Paper loaded Plugin Portal, ran commands, installed ViaVersion from Modrinth, verified the JAR, and shut down cleanly)

This does not publish or release a plugin version.