### PR TITLE
Add combined outdated plugin workflow

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -152,6 +152,10 @@ such as `[PP] viaversion [GITHUB].jar`. GitHub releases with no matching asset
 are skipped, while multiple matching assets in the newest applicable release are
 reported as an ambiguity instead of falling back to an older release.
 
+This replaces the old startup-only adapter workflow. New GitHub and GeyserMC
+plugins should use `/pp external` and `external-plugins.yml`; do not add new
+entries to the legacy `adapters.yml` file.
+
 ```yaml
 plugins:
   floodgate:
@@ -204,10 +208,10 @@ Install failure patterns:
 
 Single plugin update:
 
-1. `/pp update <name> [--byId] [--ignoreOutdated] [--channel <name>] [--version <version>]` finds a tracked local plugin in `plugins.json`.
+1. `/pp update <name> [--byId] [--ignoreOutdated] [--refresh] [--channel <name>] [--version <version>]` finds a tracked local plugin in `plugins.json`.
 2. If `--channel <name>` is used, Plugin Portal saves that channel before updating.
 3. If `--version <version>` is used, Plugin Portal selects that exact compatible version and marks the plugin excluded from `updateAll`.
-4. Without `--version`, it compares local version to marketplace latest version.
+4. Without `--version`, it compares local version to marketplace latest version. `--refresh` first bypasses the plugin's two-hour marketplace cache.
 5. If already current, it exits unless `--ignoreOutdated` is used.
 6. It downloads the new JAR into `plugins/update/`.
 7. It removes the old local cache entry, adds the new one, and saves `plugins.json`.
@@ -293,7 +297,7 @@ Export/import:
 | `/pp help` | `pluginportal.view` | Show command help. | Also works by running `/pp`. |
 | `/pp info` | `pluginportal.view` | Show Plugin Portal version, edition, license state, and update info. | Alias: `/pp version`. |
 | `/pp version` | `pluginportal.view` | Same as `/pp info`. | Shows Licensed: Yes/No. |
-| `/pp list [--all]` | `pluginportal.view` | List marketplace and external plugins managed by Plugin Portal. | Checks and displays update status; `--all` also shows unrecognized JARs in `plugins/`. |
+| `/pp list [--all] [--outdated]` | `pluginportal.view` | List marketplace and external plugins managed by Plugin Portal. | `--outdated` shows available marketplace and external updates. `--all` also shows unrecognized JARs; the two flags cannot be combined. |
 | `/pp dump` | `pluginportal.dump` | Upload logs/support dump to MCLogs and return a support URL. | Use for diagnostics. |
 | `/pluginportal config refresh` | `pluginportal.manage.config` | Reload local plugin cache/config state. | Command root is `pluginportal config`, not `/pp config`. |
 
@@ -303,7 +307,7 @@ Export/import:
 | --- | --- | --- | --- |
 | `/pp view <name> [platform] [--byId] [--exact]` | `pluginportal.view` | View marketplace plugin details. | `--exact` also has shorthand `-e`. |
 | `/pp install <name> [platform] [channel] [--byId] [--exact] [--version <version>]` | `pluginportal.manage.install` | Install a plugin from marketplace search/API. | `channel` is positional and saved for future updates. `--exact` also has shorthand `-e`. `--version` installs an exact compatible version and excludes it from `updateAll`. |
-| `/pp update <name> [--byId] [--ignoreOutdated] [--channel <name>] [--version <version>]` | `pluginportal.maintain.update` | Update one tracked local plugin. | `--channel` changes the saved channel before updating. `--version` installs an exact compatible version and excludes it from `updateAll`. Without `--ignoreOutdated`, skips if already up to date. |
+| `/pp update <name> [--byId] [--ignoreOutdated] [--refresh] [--channel <name>] [--version <version>]` | `pluginportal.maintain.update` | Update one tracked local plugin. | `--refresh` bypasses the local marketplace cache. `--channel` changes the saved channel before updating. `--version` installs an exact compatible version and excludes it from `updateAll`. |
 | `/pp blacklist [name] [--byId]` | `pluginportal.maintain.update` | Toggle whether a plugin is skipped by `/pp updateAll`. | With no name, lists blacklisted plugins. Manual `/pp update` still works. |
 | `/pp platform <name> <platform> [--byId]` | `pluginportal.maintain.update` | Switch a tracked plugin to another available marketplace platform. | Downloads the latest compatible jar from the target platform. Restart required. |
 | `/pp delete <name> [--byId]` | `pluginportal.manage.uninstall` | Delete/uninstall a tracked local plugin. | Alias: `/pp uninstall`. Restart required. |

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/PluginPortalBase.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/PluginPortalBase.kt
@@ -157,6 +157,7 @@ object PluginPortalBase {
             DeleteSubCommand(),
             HelpSubCommand(),
             ViewSubCommand(),
+            SearchSubCommand(),
             ListSubCommand(),
             DumpSubCommand(),
             SupportSubCommand(),

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/chat/ChatUtil.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/chat/ChatUtil.kt
@@ -135,6 +135,51 @@ fun sendPluginListMessage(audience: Audience, message: String, plugins: List<Plu
     audience.sendMessage(solidLine("", ""))
 }
 
+fun sendPluginSearchResultsMessage(audience: Audience, query: String, plugins: List<Plugin>) {
+    val duplicateNames = plugins
+        .groupingBy { it.name.lowercase() }
+        .eachCount()
+        .filterValues { it > 1 }
+        .keys
+
+    audience.sendMessage(startLine().appendSecondary("Search results for \"$query\"").appendNewline())
+    plugins.take(16).forEach { plugin ->
+        val viewPlatform = plugin.platforms.best ?: return@forEach
+        val installPlatform = plugin.platforms.bestDownloadable
+        val platformSummary = plugin.platforms.available.joinToString(", ") { it.name }
+        val hover = text(plugin.name, AQUA).appendNewline()
+            .append(text("${plugin.totalDownloads.format()} downloads · $platformSummary", GRAY))
+            .appendNewline()
+            .append(text(plugin.sanitisedDescription ?: "No description available", DARK_GRAY))
+
+        var row = textSecondary(" - ")
+            .append(textPrimary(plugin.name).hoverEvent(HoverEvent.showText(hover)))
+
+        if (plugin.name.lowercase() in duplicateNames) {
+            row = row.appendDark(" (${viewPlatform.platform.name.lowercase()}:${viewPlatform.platformId})")
+        }
+
+        row = row.appendSecondary("  ").append(
+            textPrimary("View")
+                .hyperlink()
+                .showOnHover("View ${plugin.name}")
+                .suggestCommand("/pp view \"${viewPlatform.platformId}\" ${viewPlatform.platform} --byId")
+        )
+
+        if (installPlatform != null) {
+            row = row.appendSecondary(" | ").append(
+                textPrimary("Install")
+                    .hyperlink()
+                    .showOnHover("Install ${plugin.name} from ${installPlatform.platform.name}")
+                    .suggestCommand("/pp install \"${installPlatform.platformId}\" ${installPlatform.platform} --byId")
+            )
+        }
+
+        audience.sendMessage(row)
+    }
+    audience.sendMessage(solidLine("", ""))
+}
+
 fun sendLocalPluginListMessage(audience: Audience, message: String, plugins: List<LocalPlugin>, command: String, commandSuffix: String = "") {
     audience.sendMessage(startLine().appendSecondary(message).appendNewline())
     plugins.forEach { plugin ->

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/HelpSubCommand.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/HelpSubCommand.kt
@@ -46,7 +46,11 @@ class HelpSubCommand {
         message = if (pageNumber == 1) {
             message.append(section("Plugins"))
                 .appendNewline()
-                .append(helpLine("/pp list", "Installed"))
+                .append(helpLine("/pp list [--outdated]", "Installed", details = listOf(
+                    "--outdated shows marketplace and external updates."
+                )))
+                .appendNewline()
+                .append(helpLine("/pp search <query> [platform]", "Search marketplace"))
                 .appendNewline()
                 .append(helpLine("/pp view <plugin> [platform]", "Details", details = listOf(
                     "Flags: --byId, --exact or -e",
@@ -60,7 +64,8 @@ class HelpSubCommand {
                 )))
                 .appendNewline()
                 .append(helpLine("/pp update <plugin>", "Update", details = listOf(
-                    "Flags: --byId, --ignoreOutdated, --channel <name>, --version <version>",
+                    "Flags: --byId, --ignoreOutdated, --refresh, --channel <name>, --version <version>",
+                    "--refresh bypasses Plugin Portal's local marketplace cache.",
                     "--channel disambiguates duplicate version names.",
                     "Example: /pp update luckperms --version 5.4.134"
                 )))

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/InstallSubCommand.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/InstallSubCommand.kt
@@ -127,7 +127,7 @@ class InstallSubCommand {
             ifMore = {
                 sendPluginListMessage(
                     audience,
-                    "Multiple plugins found, click one to prompt install command",
+                    "Choose a plugin to install",
                     it,
                     "install",
                     buildInstallSuggestionSuffix(platform, channel, exact, versionNumber)

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/ListSubCommand.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/ListSubCommand.kt
@@ -1,6 +1,7 @@
 package gg.flyte.pluginportal.common.commands
 
 import com.google.gson.JsonParser
+import gg.flyte.pluginportal.common.API
 import gg.flyte.pluginportal.common.PluginPortalBase
 import gg.flyte.pluginportal.common.Constants
 import gg.flyte.pluginportal.common.adapters.external.ExternalPluginConfig
@@ -13,6 +14,7 @@ import gg.flyte.pluginportal.common.managers.ExternalPluginResult
 import gg.flyte.pluginportal.common.managers.LocalPluginCache
 import gg.flyte.pluginportal.common.managers.MarketplacePluginCache
 import gg.flyte.pluginportal.common.types.LocalPlugin
+import gg.flyte.pluginportal.common.types.Version
 import gg.flyte.pluginportal.common.util.HashType
 import gg.flyte.pluginportal.common.util.SharedComponents
 import gg.flyte.pluginportal.common.util.async
@@ -41,31 +43,74 @@ class ListSubCommand {
         audience: Audience,
         @Switch("detailed") detailed: Boolean = false,
         @Switch("all") all: Boolean = false,
+        @Switch("outdated") outdated: Boolean = false,
     ) {
         async {
+            if (all && outdated) return@async audience.sendFailure("Use either --all or --outdated, not both")
+
             val plugins = LocalPluginCache
                 .sortedBy { plugin -> plugin.name }
                 .filter { plugin -> plugin.name != PluginPortalBase.plugin.name }
-            val externalPlugins = ExternalPluginManager.configuredPlugins().map { (config, state) ->
+            val marketplaceUpdates = if (outdated && plugins.isNotEmpty()) {
+                val remotes = API.getAllPluginsByPlatformIds(plugins.map(LocalPlugin::platformWithId))
+                    ?: return@async audience.sendFailure("Could not check marketplace plugins for updates")
+                plugins.mapNotNull { local ->
+                    val remote = remotes[local.platform]?.get(local.platformId) ?: return@mapNotNull null
+                    local.targetUpdateVersion(remote)?.let { version -> MarketplaceUpdate(local, version) }
+                }
+            } else emptyList()
+            val checkedExternalPlugins = ExternalPluginManager.configuredPlugins().map { (config, state) ->
                 ExternalListEntry(config, state, ExternalPluginManager.check(config.id))
             }
+            val externalPlugins = if (outdated) {
+                checkedExternalPlugins.filter { entry -> entry.state?.installed != null && entry.check.updateAvailable }
+            } else checkedExternalPlugins
+            val failedExternalChecks = if (outdated) {
+                checkedExternalPlugins.filter { entry -> entry.state?.installed != null && !entry.check.success }
+            } else emptyList()
             val unrecognizedJars = if (all) findUnrecognizedJars(plugins, externalPlugins) else emptyList()
 
-            if (plugins.isEmpty() && externalPlugins.isEmpty() && unrecognizedJars.isEmpty()) return@async audience.sendMessage(
-                Component.text("No plugins found", NamedTextColor.GRAY).boxed())
+            if (outdated && marketplaceUpdates.isEmpty() && externalPlugins.isEmpty() && failedExternalChecks.isEmpty()) {
+                return@async audience.sendSuccess("All managed plugins are up to date")
+            }
+            if (!outdated && plugins.isEmpty() && externalPlugins.isEmpty() && unrecognizedJars.isEmpty()) {
+                return@async audience.sendMessage(Component.text("No plugins found", NamedTextColor.GRAY).boxed())
+            }
 
-            var message = Component.text("Plugins managed by Plugin Portal", NamedTextColor.GRAY)
+            var message = Component.text(if (outdated) "Outdated plugins" else "Plugins managed by Plugin Portal", NamedTextColor.GRAY)
             val console = audience.isConsole()
             val showDetails = detailed || console
 
-            plugins.forEach { plugin ->
-                message = message.append(Component.text("\n"))
-                    .append(if (showDetails) getDetailedPluginLine(plugin) else getCompactPluginLine(plugin, console))
+            if (outdated) {
+                marketplaceUpdates.forEach { update ->
+                    message = message.append(Component.text("\n"))
+                        .append(getOutdatedMarketplaceLine(update, showDetails, console))
+                }
+            } else {
+                plugins.forEach { plugin ->
+                    message = message.append(Component.text("\n"))
+                        .append(if (showDetails) getDetailedPluginLine(plugin) else getCompactPluginLine(plugin, console))
+                }
             }
 
             externalPlugins.forEach { plugin ->
                 message = message.append(Component.text("\n"))
-                    .append(if (showDetails) getDetailedExternalPluginLine(plugin) else getCompactExternalPluginLine(plugin))
+                    .append(
+                        if (outdated) getOutdatedExternalPluginLine(plugin, showDetails, console)
+                        else if (showDetails) getDetailedExternalPluginLine(plugin)
+                        else getCompactExternalPluginLine(plugin)
+                    )
+            }
+
+            if (failedExternalChecks.isNotEmpty()) {
+                message = message.append(Component.text("\n\n"))
+                    .append(textSecondary("Could not check external plugins"))
+                failedExternalChecks.forEach { entry ->
+                    message = message.append(Component.text("\n"))
+                        .append(textDark(" - "))
+                        .appendPrimary(entry.config.id)
+                        .appendSecondary(": ${entry.check.message}")
+                }
             }
 
             if (unrecognizedJars.isNotEmpty()) {
@@ -82,6 +127,38 @@ class ListSubCommand {
         }
     }
 
+    private fun getOutdatedMarketplaceLine(update: MarketplaceUpdate, detailed: Boolean, console: Boolean): Component {
+        val plugin = update.plugin
+        var line = textDark(" - ")
+            .append(
+                textPrimary(plugin.name)
+                    .showOnHover("View ${plugin.name}")
+                    .suggestCommand("/pp view \"${plugin.platformId}\" ${plugin.platform} --byId")
+            )
+            .appendDark(" (${plugin.platform.name}) ")
+
+        if (detailed) {
+            line = line.appendSecondary("id=${plugin.platformId} ")
+        }
+
+        line = line
+            .append(Component.text(plugin.version, NamedTextColor.RED))
+            .appendDark(" → ")
+            .append(Component.text(update.version.versionNumber, NamedTextColor.GREEN))
+
+        if (plugin.excludedFromUpdates) line = line.appendDark(" (skipped by updateAll)")
+        if (!console) {
+            line = line.appendSecondary("  ").append(
+                textPrimary("Update")
+                    .hyperlink()
+                    .showOnHover("Update ${plugin.name}")
+                    .suggestCommand("/pp update \"${plugin.platformId}\" --byId")
+            )
+        }
+
+        return line
+    }
+
     private fun getCompactExternalPluginLine(entry: ExternalListEntry): Component {
         val installed = entry.state?.installed?.version ?: "not installed"
         val summary = listOfNotNull(installed, entry.status()).joinToString(" — ")
@@ -93,6 +170,35 @@ class ListSubCommand {
             )
             .append(textDark(" (EXTERNAL/${entry.config.provider.uppercase()}) "))
             .append(textSecondary(summary))
+    }
+
+    private fun getOutdatedExternalPluginLine(entry: ExternalListEntry, detailed: Boolean, console: Boolean): Component {
+        val installed = entry.state?.installed ?: return getCompactExternalPluginLine(entry)
+        val available = entry.check.artifact ?: return getCompactExternalPluginLine(entry)
+        var line = textDark(" - ")
+            .append(
+                textPrimary(entry.config.id)
+                    .showOnHover("External plugin: ${entry.config.sourceId}")
+                    .suggestCommand("/pp external check ${entry.config.id}")
+            )
+            .appendDark(" (EXTERNAL/${entry.config.provider.uppercase()}) ")
+
+        if (detailed) line = line.appendSecondary("source=${entry.config.sourceId} ")
+
+        line = line
+            .append(Component.text(installed.version, NamedTextColor.RED))
+            .appendDark(" → ")
+            .append(Component.text(available.version, NamedTextColor.GREEN))
+
+        if (!console) {
+            line = line.appendSecondary("  ").append(
+                textPrimary("Update")
+                    .hyperlink()
+                    .showOnHover("Update ${entry.config.id}")
+                    .suggestCommand("/pp external update ${entry.config.id}")
+            )
+        }
+        return line
     }
 
     private fun getDetailedExternalPluginLine(entry: ExternalListEntry): Component {
@@ -131,6 +237,11 @@ class ListSubCommand {
         val config: ExternalPluginConfig,
         val state: ExternalPluginState?,
         val check: ExternalPluginResult
+    )
+
+    private data class MarketplaceUpdate(
+        val plugin: LocalPlugin,
+        val version: Version,
     )
 
     private fun getCompactPluginLine(plugin: LocalPlugin, console: Boolean): Component {

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/SearchSubCommand.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/SearchSubCommand.kt
@@ -1,0 +1,37 @@
+package gg.flyte.pluginportal.common.commands
+
+import gg.flyte.pluginportal.common.chat.sendFailure
+import gg.flyte.pluginportal.common.chat.sendPluginSearchResultsMessage
+import gg.flyte.pluginportal.common.commands.lamp.MarketplacePluginSuggestionProvider
+import gg.flyte.pluginportal.common.managers.MarketplacePluginCache
+import gg.flyte.pluginportal.common.types.enums.MarketplacePlatform
+import gg.flyte.pluginportal.common.util.async
+import net.kyori.adventure.audience.Audience
+import revxrsal.commands.annotation.Command
+import revxrsal.commands.annotation.Named
+import revxrsal.commands.annotation.Optional
+import revxrsal.commands.annotation.Subcommand
+import revxrsal.commands.annotation.SuggestWith
+import revxrsal.commands.bukkit.annotation.CommandPermission
+
+@Command("pp", "pluginportal", "ppm")
+class SearchSubCommand {
+
+    @Subcommand("search")
+    @CommandPermission("pluginportal.view")
+    fun searchCommand(
+        audience: Audience,
+        @Named("query") @SuggestWith(MarketplacePluginSuggestionProvider::class) query: String,
+        @Optional @Named("platform") platform: MarketplacePlatform? = null,
+    ) = async {
+        val plugins = MarketplacePluginCache.getFilteredPlugins(query, platform)
+            .let { matches -> with(MarketplacePluginCache) { matches.sortedByRelevance(query) } }
+
+        if (plugins.isEmpty()) {
+            audience.sendFailure("No plugins found")
+            return@async
+        }
+
+        sendPluginSearchResultsMessage(audience, query, plugins)
+    }
+}

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/UpdateSubCommand.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/UpdateSubCommand.kt
@@ -34,6 +34,7 @@ class UpdateSubCommand {
         @Named("name") @SuggestWith(InstalledPluginSuggestionProvider::class) name: String,
         @Switch("byId") byId: Boolean = false, // @Suggest("--byId", "--ignoreOutdated", "-b", "-i", "-bi")
         @Switch("ignoreOutdated") ignoreOutdated: Boolean = false,
+        @Switch("refresh") refresh: Boolean = false,
         @Optional @Flag("channel") @SuggestWith(ReleaseChannelSuggestionProvider::class) channel: String? = null,
         @Optional @Flag("version") versionNumber: String? = null,
     ) {
@@ -41,28 +42,39 @@ class UpdateSubCommand {
             audience,
             name,
             byId,
-            ifSingle = { plugin: LocalPlugin -> handleSinglePlugin(audience, plugin, ignoreOutdated, channel, versionNumber) }.async(),
+            ifSingle = { plugin: LocalPlugin -> handleSinglePlugin(audience, plugin, ignoreOutdated, refresh, channel, versionNumber) }.async(),
             ifMore = { plugins: List<LocalPlugin> ->
                 sendLocalPluginListMessage(
                     audience,
                     "Multiple plugins found, click one to prompt update command",
                     plugins,
                     "update",
-                    buildUpdateSuggestionSuffix(ignoreOutdated, channel, versionNumber)
+                    buildUpdateSuggestionSuffix(ignoreOutdated, refresh, channel, versionNumber)
                 )
             },
 
         )
     }
 
-    private fun handleSinglePlugin(audience: Audience, localPlugin: LocalPlugin, ignoreOutdated: Boolean, channel: String?, versionNumber: String?) {
+    private fun handleSinglePlugin(
+        audience: Audience,
+        localPlugin: LocalPlugin,
+        ignoreOutdated: Boolean,
+        refresh: Boolean,
+        channel: String?,
+        versionNumber: String?,
+    ) {
         val targetChannel = channel?.takeIf { it.isNotBlank() }
         val exactVersionNumber = versionNumber?.takeIf { it.isNotBlank() }
-        var marketplacePluginOverride: Plugin? = null
+        var marketplacePluginOverride: Plugin? = if (refresh) {
+            MarketplacePluginCache.refreshPluginById(localPlugin.platform, localPlugin.platformId)
+                ?: return audience.sendFailure("Could not refresh ${localPlugin.name} from the marketplace")
+        } else null
         var targetVersionOverride: Version? = null
 
         if (exactVersionNumber != null) {
-            val marketplacePlugin = MarketplacePluginCache.getCachedPluginById(localPlugin.platform, localPlugin.platformId)
+            val marketplacePlugin = marketplacePluginOverride
+                ?: MarketplacePluginCache.getCachedPluginById(localPlugin.platform, localPlugin.platformId)
                 ?: runCatching { MarketplacePluginCache.getOrFetchPluginById(localPlugin.platform, localPlugin.platformId) }.getOrNull()
                 ?: return audience.sendFailure("Could not find plugin in marketplace (${localPlugin.name} with ID ${localPlugin.platformId} on ${localPlugin.platform})")
             val platformPlugin = marketplacePlugin.platform(localPlugin.platform)
@@ -101,7 +113,9 @@ class UpdateSubCommand {
             LocalPluginCache.save()
         }
 
-        if (exactVersionNumber == null && !ignoreOutdated && localPlugin.isUpToDate) {
+        val updateTarget = marketplacePluginOverride?.let(localPlugin::targetUpdateVersion)
+        val isUpToDate = marketplacePluginOverride?.let { updateTarget == null } ?: localPlugin.isUpToDate
+        if (exactVersionNumber == null && !ignoreOutdated && isUpToDate) {
             return audience.sendSuccess("Plugin is already up to date")
         }
 
@@ -122,16 +136,25 @@ class UpdateSubCommand {
         )
 
         if (response.success) {
-            audience.sendMessage(SharedComponents.successfullyInstalledPlugin(localPlugin.name, targetPlatform))
+            val installedVersion = response.meta?.version ?: targetVersionOverride?.versionNumber ?: updateTarget?.versionNumber ?: "unknown"
+            audience.sendMessage(
+                SharedComponents.successfullyUpdatedPlugin(
+                    localPlugin.name,
+                    localPlugin.version,
+                    installedVersion,
+                    targetPlatform,
+                )
+            )
             if (exactVersionNumber != null) audience.sendInfo("${localPlugin.name} is excluded from updateAll because you installed a specific version.")
         } else {
             response.alertFailure(audience)
         }
     }
 
-    private fun buildUpdateSuggestionSuffix(ignoreOutdated: Boolean, channel: String?, versionNumber: String?): String {
+    private fun buildUpdateSuggestionSuffix(ignoreOutdated: Boolean, refresh: Boolean, channel: String?, versionNumber: String?): String {
         val parts = mutableListOf<String>()
         if (ignoreOutdated) parts += "--ignoreOutdated"
+        if (refresh) parts += "--refresh"
         channel?.takeIf { it.isNotBlank() }?.let { parts += "--channel \"$it\"" }
         versionNumber?.takeIf { it.isNotBlank() }?.let { parts += "--version \"$it\"" }
         return if (parts.isEmpty()) "" else " ${parts.joinToString(" ")}"

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/ViewSubCommand.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/ViewSubCommand.kt
@@ -29,7 +29,7 @@ class ViewSubCommand {
             byId,
             exact = exact,
             ifSingle = { audience.sendMessage(it.getImageComponent().boxed()) },
-            ifMore = { sendPluginListMessage(audience, "Multiple plugins found, click one to view more information", it, "view") }
+            ifMore = { sendPluginListMessage(audience, "Choose a plugin to view", it, "view") }
         )
     }
 }

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/MarketplacePluginCache.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/MarketplacePluginCache.kt
@@ -23,6 +23,13 @@ import java.time.temporal.ChronoUnit
 
 object MarketplacePluginCache: PluginCache<Plugin>() {
 
+    internal sealed interface SearchResolution {
+        data object NotFound : SearchResolution
+        data class Exact(val plugin: Plugin) : SearchResolution
+        data class AmbiguousExact(val plugins: List<Plugin>) : SearchResolution
+        data class Results(val plugins: List<Plugin>) : SearchResolution
+    }
+
     private val pp: JavaPlugin get() = PluginPortalBase.plugin
 
     private val pluginCache: Cache<PlatformId, Plugin> = CacheBuilder.newBuilder().maximumSize(10_000).expireAfterWrite(Duration.of(2, ChronoUnit.HOURS)).build()
@@ -62,6 +69,13 @@ object MarketplacePluginCache: PluginCache<Plugin>() {
             pp.logger.warning("MarketplaceCache failed to fetch ($platform $platformId)")
             return null
         }
+        putPlugin(remote, lookupId)
+        return remote
+    }
+
+    fun refreshPluginById(platform: MarketplacePlatform, platformId: String): Plugin? {
+        val lookupId = PlatformId(platformId, platform)
+        val remote = API.getPluginByPlatformId(lookupId) ?: return null
         putPlugin(remote, lookupId)
         return remote
     }
@@ -114,18 +128,29 @@ object MarketplacePluginCache: PluginCache<Plugin>() {
             }
 
             else -> {
-                var plugins = getFilteredPlugins(name, platform)
-                if (exact) {
-                    plugins = plugins.filter { it.name.equals(name, true) }
-                } else {
-                    plugins = plugins.preferUniqueExactName(name)
-                }
-                when {
-                    plugins.isEmpty() -> audience.sendFailure("No plugins found")
-                    plugins.size == 1 -> ifSingle(plugins.first())
-                    else -> ifMore(plugins.sortedByRelevance(name))
+                when (val resolution = resolvePluginSearch(name, getFilteredPlugins(name, platform), exact)) {
+                    SearchResolution.NotFound -> audience.sendFailure("No plugins found")
+                    is SearchResolution.Exact -> ifSingle(resolution.plugin)
+                    is SearchResolution.AmbiguousExact -> ifMore(resolution.plugins)
+                    is SearchResolution.Results -> ifMore(resolution.plugins)
                 }
             }
+        }
+    }
+
+    internal fun resolvePluginSearch(
+        query: String,
+        plugins: List<Plugin>,
+        exactOnly: Boolean = false,
+    ): SearchResolution {
+        val ranked = plugins.sortedByRelevance(query)
+        val exactMatches = ranked.filter { it.name.equals(query, ignoreCase = true) }
+
+        return when {
+            exactMatches.size == 1 -> SearchResolution.Exact(exactMatches.first())
+            exactMatches.size > 1 -> SearchResolution.AmbiguousExact(exactMatches)
+            exactOnly || ranked.isEmpty() -> SearchResolution.NotFound
+            else -> SearchResolution.Results(ranked)
         }
     }
 
@@ -190,11 +215,6 @@ object MarketplacePluginCache: PluginCache<Plugin>() {
      */
     fun List<Plugin>.sortedByRelevance(query: String): List<Plugin> = sortedByDescending {
         it.totalDownloads * if (query.equals(it.name, true)) 50 else 1 // Arbitrary bias to exact matches
-    }
-
-    internal fun List<Plugin>.preferUniqueExactName(query: String): List<Plugin> {
-        val exactMatches = filter { it.name.equals(query, ignoreCase = true) }
-        return if (exactMatches.size == 1) exactMatches else this
     }
 
     private fun String.normalizedLookup(): String =

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/util/SharedComponents.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/util/SharedComponents.kt
@@ -18,10 +18,22 @@ object SharedComponents {
         .clickEvent(ClickEvent.openUrl("https://flyte.gg/discord"))
         .hyperlink()
 
-    fun successfullyInstalledPlugin(pluginName: String, platform: MarketplacePlatform, plsrestart: Boolean = true) =
-        status(Status.SUCCESS, "Downloaded $pluginName from ${platform.name}.")
-            .also { if (plsrestart) it.appendSecondary("\n- Please restart your server to enable this plugin") }
-            .boxed()
+    fun successfullyInstalledPlugin(pluginName: String, platform: MarketplacePlatform, plsrestart: Boolean = true): Component {
+        var message = status(Status.SUCCESS, "Downloaded $pluginName from ${platform.name}.")
+        if (plsrestart) message = message.appendSecondary("\n- Please restart your server to enable this plugin")
+        return message.boxed()
+    }
+
+    fun successfullyUpdatedPlugin(
+        pluginName: String,
+        previousVersion: String,
+        installedVersion: String,
+        platform: MarketplacePlatform,
+    ) = status(Status.SUCCESS, "Updated ")
+        .appendPrimary(pluginName)
+        .appendSecondary(": $previousVersion → $installedVersion from ${platform.name}.")
+        .appendSecondary("\n- Please restart your server to apply this update")
+        .boxed()
 
     fun getUpdateBeforeAndAfterComponent(plugin: LocalPlugin, new: Plugin) = Component.text(
         "(",

--- a/common/src/test/kotlin/gg/flyte/pluginportal/common/managers/MarketplacePluginCacheTest.kt
+++ b/common/src/test/kotlin/gg/flyte/pluginportal/common/managers/MarketplacePluginCacheTest.kt
@@ -8,34 +8,48 @@ import java.util.Date
 
 class MarketplacePluginCacheTest {
     @Test
-    fun `a unique exact name wins over related prefix matches`() {
-        val exact = plugin("ViaVersion")
-        val related = plugin("ViaVersionStatus")
+    fun `installing a unique exact name selects it over related search results`() {
+        val exact = plugin("ViaVersion", downloads = 1)
+        val related = plugin("ViaVersionStatus", downloads = 10_000)
 
-        val selected = with(MarketplacePluginCache) {
-            listOf(related, exact).preferUniqueExactName("viaversion")
-        }
+        val resolution = MarketplacePluginCache.resolvePluginSearch("viaversion", listOf(related, exact))
 
-        assertEquals(listOf(exact), selected)
+        assertEquals(MarketplacePluginCache.SearchResolution.Exact(exact), resolution)
     }
 
     @Test
-    fun `duplicate exact names still require disambiguation`() {
-        val first = plugin("ViaVersion")
-        val second = plugin("viaversion")
-        val matches = listOf(first, second)
+    fun `duplicate exact names exclude merely related plugins from choices`() {
+        val first = plugin("ViaVersion", downloads = 20)
+        val second = plugin("viaversion", downloads = 10)
+        val related = plugin("ViaVersionStatus", downloads = 1_000)
 
-        val selected = with(MarketplacePluginCache) {
-            matches.preferUniqueExactName("ViaVersion")
-        }
+        val resolution = MarketplacePluginCache.resolvePluginSearch("ViaVersion", listOf(related, second, first))
 
-        assertEquals(matches, selected)
+        assertEquals(MarketplacePluginCache.SearchResolution.AmbiguousExact(listOf(first, second)), resolution)
     }
 
-    private fun plugin(name: String) = Plugin(
+    @Test
+    fun `a fuzzy result is presented for confirmation instead of auto-selected`() {
+        val related = plugin("ViaVersionStatus")
+
+        val resolution = MarketplacePluginCache.resolvePluginSearch("ViaVersionSta", listOf(related))
+
+        assertEquals(MarketplacePluginCache.SearchResolution.Results(listOf(related)), resolution)
+    }
+
+    @Test
+    fun `exact mode rejects search results without an exact name`() {
+        val related = plugin("ViaVersionStatus")
+
+        val resolution = MarketplacePluginCache.resolvePluginSearch("ViaVersion", listOf(related), exactOnly = true)
+
+        assertEquals(MarketplacePluginCache.SearchResolution.NotFound, resolution)
+    }
+
+    private fun plugin(name: String, downloads: Int = 0) = Plugin(
         id = name,
         name = name,
-        totalDownloads = 0,
+        totalDownloads = downloads,
         platforms = Platforms(null, null, null, null),
         createdAt = Date(0),
         updatedAt = Date(0)

--- a/plugin/src/main/kotlin/gg/flyte/pluginportal/plugin/commands/UpdateAllSubCommand.kt
+++ b/plugin/src/main/kotlin/gg/flyte/pluginportal/plugin/commands/UpdateAllSubCommand.kt
@@ -12,6 +12,7 @@ import gg.flyte.pluginportal.common.types.Plugin
 import gg.flyte.pluginportal.common.types.enums.MarketplacePlatform
 import gg.flyte.pluginportal.common.util.ActionResponseComponent
 import gg.flyte.pluginportal.common.util.ActionResponseString
+import gg.flyte.pluginportal.common.util.SharedComponents
 import gg.flyte.pluginportal.common.util.async
 import gg.flyte.pluginportal.plugin.commands.lamp.RequiresAuth
 import net.kyori.adventure.audience.Audience
@@ -111,13 +112,12 @@ class UpdateAllSubCommand {
                         if (response.success) {
                             successCount++
                             audience.sendMessage(
-                                Component.text("[SUCCESS]: ", NamedTextColor.GREEN)
-                                    .appendSecondary("Updated ")
-                                    .appendPrimary(localPlugin.name)
-                                    .appendSecondary(" from ")
-                                    .appendPrimary(platform.name)
-                                    .appendSecondary("...")
-                                    .boxed()
+                                SharedComponents.successfullyUpdatedPlugin(
+                                    localPlugin.name,
+                                    localPlugin.version,
+                                    response.meta?.version ?: localPlugin.targetUpdateVersion(marketplacePlugin)?.versionNumber ?: "unknown",
+                                    platform,
+                                )
                             )
                         } else {
                             failCount++

--- a/scripts/smoke-run-paper.ts
+++ b/scripts/smoke-run-paper.ts
@@ -36,13 +36,26 @@ try {
   child.stdin.write("pluginportal\n");
   await expectOccurrences(/\/pp install/g, 2, "the pluginportal command alias");
 
-  child.stdin.write("pp install ViaVersion MODRINTH --exact\n");
+  child.stdin.write("pp install ViaVersion MODRINTH\n");
   await expectOutput(
     /Downloaded ViaVersion from MODRINTH|Successfully installed ViaVersion/i,
-    "a ViaVersion install from the public API",
+    "an exact-name ViaVersion install from the public API",
     75_000,
   );
   await assertInstalled("ViaVersion");
+
+  child.stdin.write("pp install DKY9btbd MODRINTH --byId\n");
+  await expectOutput(/Downloaded WorldGuard from MODRINTH/i, "a Minecraft-compatible WorldGuard install", 75_000);
+  await assertTrackedVersionSupports("WorldGuard", "1.21.11");
+
+  child.stdin.write("pp search ViaVersion\n");
+  await expectOutput(/ViaVersionStatus/i, "related marketplace search results", 30_000);
+
+  child.stdin.write("pp list --outdated\n");
+  await expectOutput(/All managed plugins are up to date/i, "the combined outdated list", 30_000);
+
+  child.stdin.write("pp update ViaVersion --refresh\n");
+  await expectOutput(/Plugin is already up to date/i, "a fresh single-plugin update check", 30_000);
 
   child.stdin.write("stop\n");
   const exitCode = await waitForExit(45_000);
@@ -103,6 +116,29 @@ async function assertInstalled(pluginName: string) {
   const installed = files.some((file) => file.endsWith(".jar") && file.toLowerCase().includes(pluginName.toLowerCase()));
   if (!installed) {
     throw new Error(`The install command succeeded but no ${pluginName} JAR exists in ${pluginsDirectory}.`);
+  }
+}
+
+async function assertTrackedVersionSupports(pluginName: string, minecraftVersion: string) {
+  const pluginsFile = join(runDirectory, "plugins", "PluginPortal", "plugins.json");
+  let tracked: { name: string; version: string; platform: string; platformId: string } | undefined;
+
+  for (let attempt = 0; attempt < 25 && !tracked; attempt++) {
+    const contents = await readFile(pluginsFile, "utf8").catch(() => "[]");
+    tracked = (JSON.parse(contents) as Array<typeof tracked>).find((plugin) => plugin?.name === pluginName);
+    if (!tracked) await Bun.sleep(200);
+  }
+  if (!tracked) throw new Error(`${pluginName} was downloaded but not written to plugins.json.`);
+
+  const response = await fetch(
+    `https://v3.pluginportal.link/versions/platform/${tracked.platform.toLowerCase()}/${tracked.platformId}?limit=500&offset=0`,
+  );
+  if (!response.ok) throw new Error(`Could not verify ${pluginName} compatibility: API returned ${response.status}.`);
+
+  const payload = await response.json() as { versions?: Array<{ versionNumber: string; mcVersions?: string[] }> };
+  const version = payload.versions?.find((candidate) => candidate.versionNumber === tracked.version);
+  if (!version?.mcVersions?.includes(minecraftVersion)) {
+    throw new Error(`${pluginName} ${tracked.version} does not explicitly support Minecraft ${minecraftVersion}.`);
   }
 }
 


### PR DESCRIPTION
## Summary
- add `/pp list --outdated` for one marketplace-and-external update view
- show installed and available versions with direct update actions, including updateAll exclusions
- add `/pp update <plugin> --refresh` to bypass the two-hour client metadata cache on demand
- show the actual old and installed versions after single and bulk updates
- add `/pp search` so discovery always shows related results while install/view only auto-select a unique exact name
- distinguish duplicate exact names with provider IDs
- document the external plugin system as the replacement for legacy startup-only adapters
- keep the existing release-channel default unchanged in this change

## Verification
- `make check`
- `./gradlew :common:test :plugin:test`
- `./gradlew :plugin:paperSmoke`
- real Paper 1.21.11 smoke installed ViaVersion by its plain exact name, returned ViaVersionStatus in `/pp search`, installed a WorldGuard version whose live API metadata explicitly supports 1.21.11, ran `/pp list --outdated`, and ran `/pp update ViaVersion --refresh`
- live Hangar production recognition independently verified Plugin Portal 3.8.4 as 3.8.4; #87 was closed separately

Closes #101
Closes #103
Closes #111
Closes #112

#83 remains open until the Minecraft-version selection fix is included in a public plugin release. #102 remains open for the same release boundary.

This does not publish or release a plugin version.