### PR TITLE
Unify managed and external plugin list output

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -181,6 +181,7 @@ plugins:
 | `/pp external check <id>` | Resolve the latest matching provider artifact without downloading it. |
 | `/pp external install <id>` | Install a configured external plugin into `plugins/`. |
 | `/pp external update <id>` | Stage an installed external plugin update in `plugins/update/`. |
+| `/pp external uninstall <id>` | Remove an installed or staged external plugin JAR. The configuration remains available for reinstalling it later. |
 | `/pp external invalidate <id>` | Force the next eligible update to download the latest artifact again. |
 | `/pp external updateAll` | Explicitly update installed `manual` and `auto` entries. |
 | `/pp external reload` | Reload user intent from `external-plugins.yml`. |
@@ -297,7 +298,7 @@ Export/import:
 | `/pp help` | `pluginportal.view` | Show command help. | Also works by running `/pp`. |
 | `/pp info` | `pluginportal.view` | Show Plugin Portal version, edition, license state, and update info. | Alias: `/pp version`. |
 | `/pp version` | `pluginportal.view` | Same as `/pp info`. | Shows Licensed: Yes/No. |
-| `/pp list [--all] [--outdated]` | `pluginportal.view` | List marketplace and external plugins managed by Plugin Portal. | `--outdated` shows available marketplace and external updates. `--all` also shows unrecognized JARs; the two flags cannot be combined. |
+| `/pp list [--all] [--outdated] [--external] [--detailed]` | `pluginportal.view` | List installed marketplace plugins and configured external plugins in separate sections. | `--outdated` includes available marketplace and external updates. `--external` limits output to external plugins. `--detailed` adds versions, IDs, and sources. `--all` also shows unrecognized JARs and cannot be combined with `--outdated` or `--external`. |
 | `/pp dump` | `pluginportal.dump` | Upload logs/support dump to MCLogs and return a support URL. | Use for diagnostics. |
 | `/pluginportal config refresh` | `pluginportal.manage.config` | Reload local plugin cache/config state. | Command root is `pluginportal config`, not `/pp config`. |
 

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/HelpSubCommand.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/HelpSubCommand.kt
@@ -46,8 +46,10 @@ class HelpSubCommand {
         message = if (pageNumber == 1) {
             message.append(section("Plugins"))
                 .appendNewline()
-                .append(helpLine("/pp list [--outdated]", "Installed", details = listOf(
-                    "--outdated shows marketplace and external updates."
+                .append(helpLine("/pp list [--outdated] [--external]", "Installed", details = listOf(
+                    "--outdated shows marketplace and external updates.",
+                    "--external shows only configured external plugins.",
+                    "--detailed includes versions, IDs, and sources."
                 )))
                 .appendNewline()
                 .append(helpLine("/pp search <query> [platform]", "Search marketplace"))

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/ListSubCommand.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/ListSubCommand.kt
@@ -44,13 +44,15 @@ class ListSubCommand {
         @Switch("detailed") detailed: Boolean = false,
         @Switch("all") all: Boolean = false,
         @Switch("outdated") outdated: Boolean = false,
+        @Switch("external") externalOnly: Boolean = false,
     ) {
         async {
             if (all && outdated) return@async audience.sendFailure("Use either --all or --outdated, not both")
+            if (all && externalOnly) return@async audience.sendFailure("Use either --all or --external, not both")
 
-            val plugins = LocalPluginCache
-                .sortedBy { plugin -> plugin.name }
-                .filter { plugin -> plugin.name != PluginPortalBase.plugin.name }
+            val plugins = if (externalOnly) emptyList() else LocalPluginCache
+                    .sortedBy { plugin -> plugin.name }
+                    .filter { plugin -> plugin.name != PluginPortalBase.plugin.name }
             val marketplaceUpdates = if (outdated && plugins.isNotEmpty()) {
                 val remotes = API.getAllPluginsByPlatformIds(plugins.map(LocalPlugin::platformWithId))
                     ?: return@async audience.sendFailure("Could not check marketplace plugins for updates")
@@ -71,40 +73,56 @@ class ListSubCommand {
             val unrecognizedJars = if (all) findUnrecognizedJars(plugins, externalPlugins) else emptyList()
 
             if (outdated && marketplaceUpdates.isEmpty() && externalPlugins.isEmpty() && failedExternalChecks.isEmpty()) {
-                return@async audience.sendSuccess("All managed plugins are up to date")
+                return@async audience.sendSuccess(
+                    if (externalOnly) "All external plugins are up to date" else "All plugins are up to date"
+                )
             }
             if (!outdated && plugins.isEmpty() && externalPlugins.isEmpty() && unrecognizedJars.isEmpty()) {
-                return@async audience.sendMessage(Component.text("No plugins found", NamedTextColor.GRAY).boxed())
+                val emptyMessage = if (externalOnly) "No external plugins configured" else "No plugins found"
+                return@async audience.sendMessage(Component.text(emptyMessage, NamedTextColor.GRAY).boxed())
             }
 
-            var message = Component.text(if (outdated) "Outdated plugins" else "Plugins managed by Plugin Portal", NamedTextColor.GRAY)
+            var message = Component.empty()
+            var hasSection = false
             val console = audience.isConsole()
             val showDetails = detailed || console
 
-            if (outdated) {
-                marketplaceUpdates.forEach { update ->
-                    message = message.append(Component.text("\n"))
-                        .append(getOutdatedMarketplaceLine(update, showDetails, console))
-                }
-            } else {
-                plugins.forEach { plugin ->
-                    message = message.append(Component.text("\n"))
-                        .append(if (showDetails) getDetailedPluginLine(plugin) else getCompactPluginLine(plugin, console))
+            fun startSection(title: String) {
+                if (hasSection) message = message.append(Component.text("\n\n"))
+                message = message.append(textPrimary(title).bold())
+                hasSection = true
+            }
+
+            val marketplaceEntries = if (outdated) marketplaceUpdates else plugins
+            if (marketplaceEntries.isNotEmpty()) {
+                startSection("Marketplace")
+                if (outdated) {
+                    marketplaceUpdates.forEach { update ->
+                        message = message.append(Component.text("\n"))
+                            .append(getOutdatedMarketplaceLine(update, showDetails, console))
+                    }
+                } else {
+                    plugins.forEach { plugin ->
+                        message = message.append(Component.text("\n"))
+                            .append(if (showDetails) getDetailedPluginLine(plugin, console) else getCompactPluginLine(plugin, console))
+                    }
                 }
             }
 
-            externalPlugins.forEach { plugin ->
-                message = message.append(Component.text("\n"))
-                    .append(
-                        if (outdated) getOutdatedExternalPluginLine(plugin, showDetails, console)
-                        else if (showDetails) getDetailedExternalPluginLine(plugin)
-                        else getCompactExternalPluginLine(plugin)
-                    )
+            if (externalPlugins.isNotEmpty()) {
+                startSection("External")
+                externalPlugins.forEach { plugin ->
+                    message = message.append(Component.text("\n"))
+                        .append(
+                            if (outdated) getOutdatedExternalPluginLine(plugin, showDetails, console)
+                            else if (showDetails) getDetailedExternalPluginLine(plugin, console)
+                            else getCompactExternalPluginLine(plugin, console)
+                        )
+                }
             }
 
             if (failedExternalChecks.isNotEmpty()) {
-                message = message.append(Component.text("\n\n"))
-                    .append(textSecondary("Could not check external plugins"))
+                startSection("External check failures")
                 failedExternalChecks.forEach { entry ->
                     message = message.append(Component.text("\n"))
                         .append(textDark(" - "))
@@ -114,8 +132,7 @@ class ListSubCommand {
             }
 
             if (unrecognizedJars.isNotEmpty()) {
-                message = message.append(Component.text("\n\n"))
-                    .append(textSecondary("Unrecognized JARs"))
+                startSection("Unrecognized JARs")
 
                 unrecognizedJars.forEach { jar ->
                     message = message.append(Component.text("\n"))
@@ -159,29 +176,32 @@ class ListSubCommand {
         return line
     }
 
-    private fun getCompactExternalPluginLine(entry: ExternalListEntry): Component {
-        val installed = entry.state?.installed?.version ?: "not installed"
-        val summary = listOfNotNull(installed, entry.status()).joinToString(" — ")
-        return Component.text(" - ", NamedTextColor.DARK_GRAY)
+    private fun getCompactExternalPluginLine(entry: ExternalListEntry, console: Boolean): Component {
+        var line = Component.text(" - ", NamedTextColor.DARK_GRAY)
             .append(
                 textPrimary(entry.config.id)
                     .hoverEvent(HoverEvent.showText(textSecondary("External plugin: ${entry.config.sourceId}")))
                     .suggestCommand("/pp external check ${entry.config.id}")
             )
-            .append(textDark(" (EXTERNAL/${entry.config.provider.uppercase()}) "))
-            .append(textSecondary(summary))
+            .append(textDark(" (${entry.providerName()}) "))
+            .append(externalStatusButton(entry))
+
+        if (!console && entry.state?.installed != null) {
+            line = line.append(Component.text(" ")).append(externalUninstallButton(entry))
+        }
+        return line
     }
 
     private fun getOutdatedExternalPluginLine(entry: ExternalListEntry, detailed: Boolean, console: Boolean): Component {
-        val installed = entry.state?.installed ?: return getCompactExternalPluginLine(entry)
-        val available = entry.check.artifact ?: return getCompactExternalPluginLine(entry)
+        val installed = entry.state?.installed ?: return getCompactExternalPluginLine(entry, console)
+        val available = entry.check.artifact ?: return getCompactExternalPluginLine(entry, console)
         var line = textDark(" - ")
             .append(
                 textPrimary(entry.config.id)
                     .showOnHover("External plugin: ${entry.config.sourceId}")
                     .suggestCommand("/pp external check ${entry.config.id}")
             )
-            .appendDark(" (EXTERNAL/${entry.config.provider.uppercase()}) ")
+            .appendDark(" (${entry.providerName()}) ")
 
         if (detailed) line = line.appendSecondary("source=${entry.config.sourceId} ")
 
@@ -191,22 +211,20 @@ class ListSubCommand {
             .append(Component.text(available.version, NamedTextColor.GREEN))
 
         if (!console) {
-            line = line.appendSecondary("  ").append(
-                textPrimary("Update")
-                    .hyperlink()
-                    .showOnHover("Update ${entry.config.id}")
-                    .suggestCommand("/pp external update ${entry.config.id}")
-            )
+            line = line.append(Component.text(" "))
+                .append(externalActionButton("Update", "/pp external update ${entry.config.id}", NamedTextColor.AQUA))
+                .append(Component.text(" "))
+                .append(externalUninstallButton(entry))
         }
         return line
     }
 
-    private fun getDetailedExternalPluginLine(entry: ExternalListEntry): Component {
+    private fun getDetailedExternalPluginLine(entry: ExternalListEntry, console: Boolean): Component {
         val installed = entry.state?.installed?.version ?: "not installed"
         val latest = entry.check.artifact?.version
         var line = Component.text(" - ", NamedTextColor.DARK_GRAY)
             .append(textPrimary(entry.config.id).suggestCommand("/pp external check ${entry.config.id}"))
-            .append(textDark(" (EXTERNAL/${entry.config.provider.uppercase()}) "))
+            .append(textDark(" (${entry.providerName()}) "))
             .append(textSecondary("source="))
             .append(textPrimary(entry.config.sourceId))
             .append(textDark(" installed="))
@@ -216,8 +234,41 @@ class ListSubCommand {
             line = line.append(textDark(" latest=")).append(Component.text(latest, NamedTextColor.GREEN))
         }
 
-        return entry.status()?.let { line.append(textDark(" status=")).append(textSecondary(it)) } ?: line
+        line = entry.status()?.let { line.append(textDark(" status=")).append(textSecondary(it)) } ?: line
+        if (!console) {
+            line = line.append(Component.text(" ")).append(externalStatusButton(entry))
+            if (entry.state?.installed != null) {
+                line = line.append(Component.text(" ")).append(externalUninstallButton(entry))
+            }
+        }
+        return line
     }
+
+    private fun ExternalListEntry.providerName(): String = when (config.provider.lowercase()) {
+        "github" -> "GitHub"
+        "geysermc" -> "GeyserMC"
+        else -> config.provider
+    }
+
+    private fun externalStatusButton(entry: ExternalListEntry): Component = when {
+        !entry.check.success -> externalActionButton("Check failed", "/pp external check ${entry.config.id}", NamedTextColor.RED)
+        entry.state?.staged != null -> externalActionButton("Staged", "/pp external check ${entry.config.id}", NamedTextColor.GRAY)
+        entry.state?.installed == null -> externalActionButton("Install", "/pp external install ${entry.config.id}", NamedTextColor.AQUA)
+        entry.check.updateAvailable -> externalActionButton("Update", "/pp external update ${entry.config.id}", NamedTextColor.AQUA)
+        else -> externalActionButton("Up to date", "/pp external check ${entry.config.id}", NamedTextColor.GRAY)
+    }
+
+    private fun externalUninstallButton(entry: ExternalListEntry): Component = externalActionButton(
+        "Uninstall",
+        "/pp external uninstall ${entry.config.id}",
+        NamedTextColor.RED
+    )
+
+    private fun externalActionButton(label: String, command: String, color: NamedTextColor): Component = textDark("[")
+        .append(Component.text(label, color))
+        .appendDark("]")
+        .showOnHover("Click to run $command", color)
+        .suggestCommand(command)
 
     private fun ExternalListEntry.status(): String? = when {
         !check.success -> "check failed"
@@ -266,7 +317,7 @@ class ListSubCommand {
         return line
     }
 
-    private fun getDetailedPluginLine(plugin: LocalPlugin): Component {
+    private fun getDetailedPluginLine(plugin: LocalPlugin, console: Boolean): Component {
         val marketplace = MarketplacePluginCache.getCachedPluginById(plugin.platform, plugin.platformId)
         val targetVersion = marketplace?.let(plugin::targetUpdateVersion)?.versionNumber
         val status = if (plugin.isUpToDate) "Up to date" else "Update available"
@@ -295,10 +346,9 @@ class ListSubCommand {
             .append(textDark(" status="))
             .append(Component.text(status, if (plugin.isUpToDate) NamedTextColor.GRAY else NamedTextColor.AQUA))
 
-        if (!plugin.isUpToDate) {
-            line = line
-                .append(textDark(" command="))
-                .append(textPrimary("/pp update \"${plugin.platformId}\" --byId"))
+        if (!console) {
+            line = line.append(Component.text(" ")).append(SharedComponents.getUpdateButton(plugin))
+                .append(Component.text(" ")).append(SharedComponents.getInstallButton(plugin, true))
         }
 
         return line

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/ExternalPluginManager.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/managers/ExternalPluginManager.kt
@@ -292,6 +292,35 @@ object ExternalPluginManager {
     }
 
     @Synchronized
+    fun uninstall(id: String): ExternalPluginResult {
+        val config = configs[id] ?: return failure("External plugin '$id' is not configured")
+        val installedFile = File(Constants.INSTALL_DIRECTORY, config.file)
+        val stagedFile = File(Constants.UPDATE_DIRECTORY, config.file)
+        val targets = listOf(installedFile, stagedFile).distinctBy { it.canonicalPath }
+        if (targets.none(File::exists) && states[id]?.installed == null && states[id]?.staged == null) {
+            return failure("${config.id} is not installed")
+        }
+
+        val failure = targets.firstNotNullOfOrNull { file ->
+            runCatching { Files.deleteIfExists(file.toPath()) }
+                .exceptionOrNull()
+                ?.let { "Could not delete ${relativePath(file)}: ${it.message ?: it::class.simpleName}" }
+        }
+        if (failure != null) return failure(failure)
+
+        states.remove(id)
+        val stateError = runCatching { saveState() }.exceptionOrNull()
+        if (stateError != null) {
+            return failure("Removed ${config.id}, but could not update external plugin state: ${stateError.message ?: stateError::class.simpleName}")
+        }
+        return ExternalPluginResult(
+            success = true,
+            message = "${config.id} has been uninstalled; restart the server to finish unloading it",
+            changed = true
+        )
+    }
+
+    @Synchronized
     fun invalidate(id: String): ExternalPluginResult {
         val config = configs[id] ?: return failure("External plugin '$id' is not configured")
         if (config.updates == ExternalUpdatePolicy.DISABLED) return failure("${config.id} has updates disabled")

--- a/plugin/src/main/kotlin/gg/flyte/pluginportal/plugin/commands/ExternalSubCommand.kt
+++ b/plugin/src/main/kotlin/gg/flyte/pluginportal/plugin/commands/ExternalSubCommand.kt
@@ -84,6 +84,13 @@ class ExternalSubCommand {
     ) = runAsync(audience) { ExternalPluginManager.update(id) }
 
     @RequiresAuth
+    @Subcommand("external uninstall")
+    fun uninstall(
+        audience: Audience,
+        @Named("id") @SuggestWith(ExternalPluginSuggestionProvider::class) id: String
+    ) = runAsync(audience) { ExternalPluginManager.uninstall(id) }
+
+    @RequiresAuth
     @Subcommand("external invalidate")
     fun invalidate(
         audience: Audience,

--- a/scripts/smoke-in-place-upgrade.ts
+++ b/scripts/smoke-in-place-upgrade.ts
@@ -1,0 +1,159 @@
+#!/usr/bin/env bun
+import { createWriteStream, existsSync } from "node:fs";
+import { copyFile, mkdir, mkdtemp, readFile, readdir, rm, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { pipeline } from "node:stream/promises";
+
+const root = process.cwd();
+const previousVersion = process.argv[2] ?? "3.8.5";
+const currentVersion = process.argv[3] ?? "3.8.6";
+const currentJar = join(root, "out", `PluginPortal-${currentVersion}.jar`);
+const cacheDir = join(root, ".cache", "upgrade-smoke");
+const previousJar = join(cacheDir, `PluginPortal-${previousVersion}.jar`);
+const paperJar = join(cacheDir, "paper-1.21.11.jar");
+const runDirectory = await mkdtemp(join(tmpdir(), "plugin-portal-upgrade-"));
+
+if (!existsSync(currentJar)) throw new Error(`Missing ${currentJar}; build the plugin first.`);
+await mkdir(cacheDir, { recursive: true });
+await downloadPreviousRelease();
+await downloadPaper();
+await mkdir(join(runDirectory, "plugins"), { recursive: true });
+await copyFile(paperJar, join(runDirectory, "server.jar"));
+await copyFile(previousJar, join(runDirectory, "plugins", basename(previousJar)));
+await writeFile(join(runDirectory, "eula.txt"), "eula=true\n");
+await writeFile(join(runDirectory, "server.properties"), "online-mode=false\nserver-port=0\n");
+
+try {
+  const previous = await startServer();
+  try {
+    await expect(previous, new RegExp(`Enabling PluginPortal v${escape(previousVersion)}`), "released plugin startup");
+    previous.write("pp install P1OZGk5p MODRINTH --byId");
+    await expect(previous, /Downloaded ViaVersion from MODRINTH|Successfully installed ViaVersion/i, "released plugin install", 75_000);
+  } finally {
+    await previous.stop();
+    assertHealthy(previous.output());
+  }
+
+  const dataFile = join(runDirectory, "plugins", "PluginPortal", "plugins.json");
+  const before = JSON.parse(await readFile(dataFile, "utf8")) as Array<{ name?: string; platformId?: string }>;
+  const tracked = before.find((plugin) => plugin.name === "ViaVersion");
+  if (!tracked?.platformId) throw new Error("Released plugin did not persist ViaVersion before upgrade.");
+
+  for (const file of await readdir(join(runDirectory, "plugins"))) {
+    if (/^PluginPortal(?:Premium)?-.*\.jar$/i.test(file)) await unlink(join(runDirectory, "plugins", file));
+  }
+  await rm(join(runDirectory, "plugins", "update"), { recursive: true, force: true });
+  await copyFile(currentJar, join(runDirectory, "plugins", basename(currentJar)));
+
+  const current = await startServer();
+  try {
+    await expect(current, new RegExp(`Enabling PluginPortal v${escape(currentVersion)}`), "upgraded plugin startup");
+    current.write("pp list");
+    await expect(current, /Marketplace[\s\S]*ViaVersion/i, "preserved managed plugin list");
+    current.write("pp update ViaVersion --refresh");
+    await expect(current, /Plugin is already up to date|Successfully updated|Downloaded ViaVersion/i, "upgraded plugin refresh", 75_000);
+  } finally {
+    await current.stop();
+    assertHealthy(current.output());
+  }
+
+  const after = JSON.parse(await readFile(dataFile, "utf8")) as Array<{ name?: string; platformId?: string }>;
+  if (!after.some((plugin) => plugin.name === "ViaVersion" && plugin.platformId === tracked.platformId)) {
+    throw new Error("ViaVersion tracking state changed or disappeared after upgrade.");
+  }
+
+  console.log(`In-place upgrade smoke passed: released ${previousVersion} state survived the ${currentVersion} JAR replacement.`);
+} finally {
+  await rm(runDirectory, { recursive: true, force: true });
+}
+
+async function startServer() {
+  const child = spawn("docker", [
+    "run", "--rm", "-i", "-v", `${runDirectory}:/server`, "-w", "/server",
+    "eclipse-temurin:21-jre", "java", "-Xms1G", "-Xmx2G", "-jar", "server.jar", "--nogui",
+  ], { stdio: ["pipe", "pipe", "pipe"] });
+  let output = "";
+  child.stdout.on("data", (chunk) => output += chunk.toString());
+  child.stderr.on("data", (chunk) => output += chunk.toString());
+  const server = {
+    output: () => output,
+    write: (command: string) => child.stdin.write(`${command}\n`),
+    stop: async () => {
+      if (child.exitCode !== null) return;
+      child.stdin.write("stop\n");
+      await waitForExit(child, 45_000);
+    },
+  };
+  await expect(server, /Done \(/, "Paper startup", 180_000);
+  assertHealthy(output);
+  return server;
+}
+
+async function expect(server: { output: () => string }, pattern: RegExp, label: string, timeoutMs = 30_000) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    if (pattern.test(clean(server.output()))) return;
+    await Bun.sleep(200);
+  }
+  throw new Error(`Timed out waiting for ${label}.\n${tail(server.output())}`);
+}
+
+function assertHealthy(output: string) {
+  const value = clean(output);
+  if (/Error occurred while enabling PluginPortal|Could not load ['"]?plugins[\\/]PluginPortal|PluginPortal[^\n]*(?:NullPointerException|NoClassDefFoundError)/i.test(value)) {
+    throw new Error(`PluginPortal failed during upgrade smoke.\n${tail(value)}`);
+  }
+}
+
+async function downloadPreviousRelease() {
+  if (existsSync(previousJar)) return;
+  const versions = await fetch("https://api.modrinth.com/v2/project/5qkQnnWO/version").then((response) => response.json()) as Array<{
+    version_number: string;
+    files: Array<{ url: string; primary: boolean }>;
+  }>;
+  const release = versions.find((candidate) => candidate.version_number === previousVersion);
+  const url = release?.files.find((file) => file.primary)?.url ?? release?.files[0]?.url;
+  if (!url) throw new Error(`Could not find released PluginPortal ${previousVersion}.`);
+  await download(url, previousJar);
+}
+
+async function downloadPaper() {
+  if (existsSync(paperJar)) return;
+  const metadata = await fetch("https://mcjars.app/api/v1/builds/paper/1.21.11").then((response) => response.json()) as {
+    builds: Array<{ jarUrl: string }>;
+  };
+  const url = metadata.builds[0]?.jarUrl;
+  if (!url) throw new Error("Could not resolve Paper 1.21.11.");
+  await download(url, paperJar);
+}
+
+async function download(url: string, destination: string) {
+  const response = await fetch(url);
+  if (!response.ok || !response.body) throw new Error(`Download failed with HTTP ${response.status}.`);
+  await pipeline(response.body, createWriteStream(destination));
+}
+
+function waitForExit(child: ChildProcessWithoutNullStreams, timeoutMs: number) {
+  if (child.exitCode !== null) return Promise.resolve(child.exitCode);
+  return new Promise<number>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("Timed out waiting for Paper to stop.")), timeoutMs);
+    child.once("exit", (code) => {
+      clearTimeout(timeout);
+      resolve(code ?? 1);
+    });
+  });
+}
+
+function clean(value: string) {
+  return value.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
+function tail(value: string, lines = 80) {
+  return clean(value).split(/\r?\n/).slice(-lines).join("\n");
+}
+
+function escape(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/scripts/smoke-run-paper.ts
+++ b/scripts/smoke-run-paper.ts
@@ -52,7 +52,7 @@ try {
   await expectOutput(/ViaVersionStatus/i, "related marketplace search results", 30_000);
 
   child.stdin.write("pp list --outdated\n");
-  await expectOutput(/All managed plugins are up to date/i, "the combined outdated list", 30_000);
+  await expectOutput(/All (?:managed )?plugins are up to date/i, "the combined outdated list", 30_000);
 
   child.stdin.write("pp update ViaVersion --refresh\n");
   await expectOutput(/Plugin is already up to date/i, "a fresh single-plugin update check", 30_000);


### PR DESCRIPTION
## Summary
- present marketplace and external adapters with consistent list formatting
- include external adapter plugins in `/pp list --outdated` without requiring `--external`
- keep `--external` as an external-only filter and preserve detailed output behind flags
- add a real in-place upgrade smoke that boots released 3.8.5, persists managed plugin state, replaces the JAR with 3.8.6, and verifies the state and update path

## Verification
- `./gradlew :plugin:compileKotlin test`
- `bun scripts/smoke-run-paper.ts`
- `bun scripts/smoke-in-place-upgrade.ts 3.8.5 3.8.6`

The upgrade smoke passed against the deployed v3 API. This PR does not publish a JAR or create a release.