### PR TITLE
Fix Modrinth version and channel selection

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -110,10 +110,11 @@ Install from command:
 2. Plugin searches marketplace cache/API.
 3. If `--byId` is used, `platform` is required and `<name>` is treated as the marketplace/platform ID.
 4. If `--exact` or `-e` is used, name search is filtered to exact case-insensitive plugin-name matches.
-5. If `--version <version>` is used, Plugin Portal selects that exact compatible version. If the version label exists on multiple channels, rerun with a channel.
-6. If one match exists, it downloads the plugin JAR into `plugins/`.
-7. It writes a tracked `LocalPlugin` entry to `plugins/PluginPortal/plugins.json`.
-8. User usually needs to restart the server for Bukkit/Paper to load the newly installed plugin.
+5. If no channel is supplied, Plugin Portal prefers `release` or `stable` builds when either is available.
+6. If `--version <version>` is used, Plugin Portal selects that exact compatible version. If the version label exists on multiple channels, rerun with a channel.
+7. If one match exists, it downloads the newest version compatible with the server software and Minecraft version into `plugins/`.
+8. It writes a tracked `LocalPlugin` entry to `plugins/PluginPortal/plugins.json`.
+9. User usually needs to restart the server for Bukkit/Paper to load the newly installed plugin.
 
 Install command arguments:
 
@@ -265,7 +266,7 @@ If the JAR is already gone, Plugin Portal removes the cache entry but reports it
 
 Recognition is for manually installed plugins.
 
-`/pp recognize <file>`:
+`/pp recognize <file> [--channel <name>]`:
 
 - Looks for the JAR in `plugins/`.
 - Allows a single partial filename match.
@@ -275,14 +276,16 @@ Recognition is for manually installed plugins.
 - Reads `polymart.yml` from the JAR if present and handles Polymart metadata locally.
 - Otherwise asks the API to recognize by hash.
 - Adds a `LocalPlugin` entry to `plugins.json`.
+- Saves `--channel` as the update channel when provided.
 - Renames the JAR to Plugin Portal's downloaded filename format when recognized.
 
-`/pp recognizeAll`:
+`/pp recognizeAll [--channel <name>]`:
 
 - Scans all JARs in `plugins/`.
 - Skips Plugin Portal itself and already tracked hashes.
 - Handles Polymart metadata first.
 - Then batch-recognizes remaining JARs by hash.
+- Saves `--channel` as the update channel for hash-recognized JARs when provided.
 - Shows recognized and unrecognized results.
 
 Export/import:
@@ -331,8 +334,8 @@ These require valid Plugin Portal entitlement unless noted. The same JAR contain
 | Command | Permission | Purpose | Notes |
 | --- | --- | --- | --- |
 | `/pp updateAll [--ignoreOutdated]` | `pluginportal.maintain.update` | Bulk update all tracked plugins. | Skips blacklisted plugins and uses each plugin's saved channel. |
-| `/pp recognize <file>` | `pluginportal.manage.recognize` | Recognize one untracked plugin JAR in the plugins folder by hash/metadata. | May rename the file to Plugin Portal format. |
-| `/pp recognizeAll` | `pluginportal.manage.recognize` | Recognize all untracked plugin JARs in the plugins folder. | Skips Plugin Portal itself and already tracked hashes. |
+| `/pp recognize <file> [--channel <name>]` | `pluginportal.manage.recognize` | Recognize one untracked plugin JAR in the plugins folder by hash/metadata. | May rename the file to Plugin Portal format. `--channel` pins future updates to that channel. |
+| `/pp recognizeAll [--channel <name>]` | `pluginportal.manage.recognize` | Recognize all untracked plugin JARs in the plugins folder. | Skips Plugin Portal itself and already tracked hashes. `--channel` applies to hash-recognized JARs. |
 | `/pp export` | `pluginportal.manage.export` | Export tracked plugin platform IDs to an MCLogs URL. | Used for migration/import. |
 | `/pp import <mclogs-url>` | `pluginportal.manage.import` | Import and install plugins from an export URL. | URL must contain `mclo.gs`. |
 | `/pp scan <file>` | `pluginportal.manage.scan` | Scan a plugin JAR for Hangar scanner alerts. | Findings are warnings, not automatic proof of malware. |

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/API.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/API.kt
@@ -26,7 +26,7 @@ data class AuthCreds(
 // ORPC Response Types (minimal, focused on what the plugin needs)
 private data class ORPCVersionsResponse(val versions: List<ORPCVersionInfo>)
 private data class ORPCVersionInfo(val version: String, val fullVersion: String, val channel: String, val stable: Boolean, val filename: String)
-private data class ORPCPlatformVersionsResponse(val versions: Array<Version>, val pagination: Pagination)
+internal data class ORPCPlatformVersionsResponse(val versions: Array<Version>, val pagination: Pagination)
 private data class ORPCUpdateResponse(val updateAvailable: Boolean, val current: ORPCVersionChannel, val latest: ORPCLatestVersion?)
 private data class ORPCVersionChannel(val version: String, val channel: String)  
 private data class ORPCLatestVersion(val version: String, val channel: String, val downloadUrl: String, val changelog: String?)
@@ -44,6 +44,19 @@ internal fun nextPlatformVersionsOffset(pagination: Pagination, currentOffset: I
 
     val nextOffset = pagination.offset + pagination.limit
     return nextOffset.takeIf { it > currentOffset }
+}
+
+internal fun collectPlatformVersionPages(fetchPage: (Int) -> ORPCPlatformVersionsResponse?): Array<Version>? {
+    val versions = mutableListOf<Version>()
+    var offset = 0
+    repeat(MAX_PLATFORM_VERSION_PAGES) {
+        val page = fetchPage(offset) ?: return null
+        versions.addAll(page.versions)
+        if (!page.pagination.hasMore) return versions.toTypedArray()
+        offset = nextPlatformVersionsOffset(page.pagination, offset, page.versions.size) ?: return null
+    }
+    // Partial results must not masquerade as a complete version history.
+    return null
 }
 
 object API {
@@ -319,11 +332,7 @@ object API {
 
     fun getPluginVersions(platformId: PlatformId, limit: Int = MAX_PLATFORM_VERSION_PAGE_SIZE): Array<Version>? {
         val pageSize = limit.coerceIn(1, MAX_PLATFORM_VERSION_PAGE_SIZE)
-        val versions = mutableListOf<Version>()
-        var offset = 0
-        var pagesFetched = 0
-
-        while (pagesFetched < MAX_PLATFORM_VERSION_PAGES) {
+        return collectPlatformVersionPages { offset ->
             val response = orpcCall(
                 "/versions/platform/${platformId.platform.name.lowercase()}/${platformId.platformId}",
                 params = mapOf(
@@ -334,26 +343,15 @@ object API {
 
             if (!response.isSuccessful()) {
                 logRequestFailure("Plugin version lookup", response)
-                return versions.takeIf { it.isNotEmpty() }?.toTypedArray()
+                return@collectPlatformVersionPages null
             }
 
-            val page = runCatching {
+            runCatching {
                 GSON.fromJson(response.body, ORPCPlatformVersionsResponse::class.java)
             }.onFailure {
                 logParseFailure("Plugin version lookup", it)
-            }.getOrNull() ?: return versions.takeIf { it.isNotEmpty() }?.toTypedArray()
-
-            versions.addAll(page.versions.asList())
-            pagesFetched++
-
-            offset = nextPlatformVersionsOffset(page.pagination, offset, page.versions.size) ?: break
+            }.getOrNull()
         }
-
-        if (pagesFetched >= MAX_PLATFORM_VERSION_PAGES) {
-            PluginPortalBase.plugin.logger.warning("Plugin version lookup stopped after $MAX_PLATFORM_VERSION_PAGES pages for ${platformId.platform} ${platformId.platformId}.")
-        }
-
-        return versions.toTypedArray()
     }
 
     fun getAllPluginsByPlatformIds(platformIds: List<PlatformId>): Map<MarketplacePlatform, Map<String, Plugin?>>? {

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/HelpSubCommand.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/commands/HelpSubCommand.kt
@@ -150,11 +150,11 @@ class HelpSubCommand {
                 "Example: /pp updateAll --ignoreOutdated"
             )))
             .appendNewline()
-            .append(helpLine("/pp recognize <file>", "Recognize", gold, listOf(
-                "Example: /pp recognize SomePlugin.jar"
+            .append(helpLine("/pp recognize <file> [--channel <name>]", "Recognize", gold, listOf(
+                "Example: /pp recognize SomePlugin.jar --channel release"
             )))
             .appendNewline()
-            .append(helpLine("/pp recognizeAll", "Recognize all", gold))
+            .append(helpLine("/pp recognizeAll [--channel <name>]", "Recognize all", gold))
             .appendNewline()
             .append(helpLine("/pp <import | export>", "Import/export", gold, listOf(
                 "Import requires an MCLogs URL created by /pp export.",

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/types/LocalPlugin.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/types/LocalPlugin.kt
@@ -4,6 +4,7 @@ import gg.flyte.pluginportal.common.API
 import gg.flyte.pluginportal.common.PlatformId
 import gg.flyte.pluginportal.common.managers.MarketplacePluginCache
 import gg.flyte.pluginportal.common.types.enums.MarketplacePlatform
+import gg.flyte.pluginportal.common.types.enums.ServerType
 import gg.flyte.pluginportal.common.util.currentMinecraftVersion
 import gg.flyte.pluginportal.common.util.currentServerTypePreference
 
@@ -33,23 +34,34 @@ data class LocalPlugin(
 
     fun targetUpdateVersion(plugin: Plugin = marketplacePlugin): Version? {
         val platformPlugin = plugin.platform(platform) ?: return null
-        val serverTypes = currentServerTypePreference()
-        val minecraftVersion = currentMinecraftVersion()
+        return targetUpdateVersion(platformPlugin, currentServerTypePreference(), currentMinecraftVersion()) {
+            API.getPluginVersions(platformPlugin.platformWithId)?.toList()
+        }
+    }
+
+    internal fun targetUpdateVersion(
+        platformPlugin: PlatformPlugin,
+        serverTypes: List<ServerType>,
+        minecraftVersion: String?,
+        fetchVersions: () -> List<Version>?,
+    ): Version? {
         val cachedTarget = platformPlugin.newestCompatibleVersion(preferredChannel, serverTypes, minecraftVersion)
 
         if (
             cachedTarget != null
+            && cachedTarget.hasResolvedChannel(preferredChannel)
             && isNewerThanInstalled(cachedTarget)
             && cachedTarget.bestServerTypeRank(serverTypes) == 0
             && (minecraftVersion == null || cachedTarget.explicitlySupportsMinecraftVersion(minecraftVersion))
         ) return cachedTarget
 
-        val fullTarget = API.getPluginVersions(platformPlugin.platformWithId)
-            ?.toList()
-            ?.newestCompatibleVersion(preferredChannel, serverTypes, minecraftVersion)
-
-        return fullTarget?.takeIf(::isNewerThanInstalled)
-            ?: cachedTarget?.takeIf(::isNewerThanInstalled)
+        val fullVersions = fetchVersions()
+        val target = if (fullVersions != null) {
+            fullVersions.newestCompatibleVersion(preferredChannel, serverTypes, minecraftVersion)
+        } else {
+            cachedTarget?.takeIf { it.hasResolvedChannel(preferredChannel) }
+        }
+        return target?.takeIf(::isNewerThanInstalled)
     }
 
     fun matchesVersion(target: Version): Boolean =

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/types/PluginTypes.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/types/PluginTypes.kt
@@ -161,11 +161,19 @@ fun PlatformPlugin.newestCompatibleVersionWithFallback(
     serverTypePreference: List<ServerType>,
     minecraftVersion: String? = null,
     fetchVersions: () -> List<Version>?
-): Version? =
-    newestCompatibleVersion(channel, serverTypePreference, minecraftVersion)
-        ?.takeIf { version -> version.isSpecificMatch(serverTypePreference, minecraftVersion) }
-        ?: fetchVersions()?.newestCompatibleVersion(channel, serverTypePreference, minecraftVersion)
-        ?: newestCompatibleVersion(channel, serverTypePreference, minecraftVersion)
+): Version? {
+    val cached = newestCompatibleVersion(channel, serverTypePreference, minecraftVersion)
+    if (cached != null && cached.hasResolvedChannel(channel) && cached.isSpecificMatch(serverTypePreference, minecraftVersion)) return cached
+
+    // A successful lookup with no match is authoritative, not a reason to reuse the slice.
+    val full = fetchVersions()
+    if (full != null) return full.newestCompatibleVersion(channel, serverTypePreference, minecraftVersion)
+    return cached?.takeIf { it.hasResolvedChannel(channel) }
+}
+
+internal fun Version.hasResolvedChannel(requestedChannel: String?): Boolean =
+    requestedChannel != null || releaseChannel.equals("release", ignoreCase = true) ||
+        releaseChannel.equals("stable", ignoreCase = true)
 
 fun PlatformPlugin.exactCompatibleVersionWithFallback(
     versionNumber: String,
@@ -190,12 +198,7 @@ private fun List<Version>.preferMinecraftVersion(minecraftVersion: String?): Lis
     val explicitMatches = filter { version -> version.explicitlySupportsMinecraftVersion(normalized) }
     if (explicitMatches.isNotEmpty()) return explicitMatches
 
-    val versionsWithoutStructuredCompatibility = filter { version -> version.mcVersions.isNullOrEmpty() }
-    return when {
-        versionsWithoutStructuredCompatibility.isNotEmpty() -> versionsWithoutStructuredCompatibility
-        any { version -> !version.mcVersions.isNullOrEmpty() } -> emptyList()
-        else -> this
-    }
+    return filter { version -> version.mcVersions.isNullOrEmpty() }
 }
 
 private fun List<Version>.preferStableChannel(requestedChannel: String?): List<Version> {
@@ -315,6 +318,8 @@ data class Version(
 
     fun explicitlySupportsMinecraftVersion(minecraftVersion: String?): Boolean {
         val normalized = normalizeMinecraftVersion(minecraftVersion) ?: return false
+        // Structured marketplace versions are exact versions, not minor-version wildcards.
+        if (!mcVersions.isNullOrEmpty()) return mcVersions.any { it.equals(normalized, ignoreCase = true) }
         return supportedMinecraftVersions.any { supported -> minecraftVersionsMatch(supported, normalized) }
     }
 

--- a/common/src/main/kotlin/gg/flyte/pluginportal/common/types/PluginTypes.kt
+++ b/common/src/main/kotlin/gg/flyte/pluginportal/common/types/PluginTypes.kt
@@ -152,6 +152,7 @@ private fun List<Version>.bestCompatibleVersion(serverTypePreference: List<Serve
 fun List<Version>.newestCompatibleVersion(channel: String?, serverTypePreference: List<ServerType>, minecraftVersion: String? = null): Version? =
     filter { version -> version.isCompatibleWith(serverTypePreference) }
         .filter { version -> channel == null || version.releaseChannel.equals(channel, ignoreCase = true) }
+        .preferStableChannel(channel)
         .preferMinecraftVersion(minecraftVersion)
         .bestCompatibleVersion(serverTypePreference)
 
@@ -189,8 +190,21 @@ private fun List<Version>.preferMinecraftVersion(minecraftVersion: String?): Lis
     val explicitMatches = filter { version -> version.explicitlySupportsMinecraftVersion(normalized) }
     if (explicitMatches.isNotEmpty()) return explicitMatches
 
-    val unknownCompatibility = filter { version -> version.supportedMinecraftVersions.isEmpty() }
-    return unknownCompatibility.ifEmpty { this }
+    val versionsWithoutStructuredCompatibility = filter { version -> version.mcVersions.isNullOrEmpty() }
+    return when {
+        versionsWithoutStructuredCompatibility.isNotEmpty() -> versionsWithoutStructuredCompatibility
+        any { version -> !version.mcVersions.isNullOrEmpty() } -> emptyList()
+        else -> this
+    }
+}
+
+private fun List<Version>.preferStableChannel(requestedChannel: String?): List<Version> {
+    if (requestedChannel != null) return this
+    val stableVersions = filter { version ->
+        version.releaseChannel.equals("release", ignoreCase = true) ||
+            version.releaseChannel.equals("stable", ignoreCase = true)
+    }
+    return stableVersions.ifEmpty { this }
 }
 
 private fun Version.isSpecificMatch(serverTypePreference: List<ServerType>, minecraftVersion: String?): Boolean {

--- a/common/src/test/kotlin/gg/flyte/pluginportal/common/APIPaginationTest.kt
+++ b/common/src/test/kotlin/gg/flyte/pluginportal/common/APIPaginationTest.kt
@@ -1,11 +1,50 @@
 package gg.flyte.pluginportal.common
 
 import gg.flyte.pluginportal.common.types.Pagination
+import gg.flyte.pluginportal.common.types.Version
+import gg.flyte.pluginportal.common.types.newestCompatibleVersion
+import gg.flyte.pluginportal.common.types.enums.ServerType
+import java.util.Date
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class APIPaginationTest {
+    private fun page(offset: Int, more: Boolean, channel: String = "release") = ORPCPlatformVersionsResponse(
+        arrayOf(Version("version-$offset", Date(1000L - offset), channel, "https://example.com/$offset.jar",
+            null, listOf("1.21.4"), arrayOf(ServerType.PAPER), null)),
+        Pagination(total = 2, limit = 1, offset = offset, hasMore = more),
+    )
+
+    @Test
+    fun `selection sees stable release on later page after compatible alpha`() {
+        val offsets = mutableListOf<Int>()
+        val versions = collectPlatformVersionPages { offset ->
+            offsets.add(offset)
+            if (offset == 0) page(0, true, "alpha") else page(1, false)
+        }
+        assertEquals(listOf(0, 1), offsets)
+        assertEquals("version-1", versions?.toList()?.newestCompatibleVersion(null, listOf(ServerType.PAPER), "1.21.4")?.versionNumber)
+    }
+
+    @Test
+    fun `later page failure discards incomplete history`() {
+        val versions = collectPlatformVersionPages { offset -> if (offset == 0) page(0, true, "alpha") else null }
+        assertNull(versions)
+    }
+
+    @Test
+    fun `non advancing page discards incomplete history`() {
+        assertNull(collectPlatformVersionPages { page(0, true) })
+    }
+
+    @Test
+    fun `endless pagination is bounded and not returned as complete`() {
+        var requests = 0
+        assertNull(collectPlatformVersionPages { offset -> requests++; page(offset, true) })
+        assertEquals(20, requests)
+    }
+
     @Test
     fun `advances to the next platform version page while more results exist`() {
         val pagination = Pagination(total = 750, limit = 500, offset = 0, hasMore = true)

--- a/common/src/test/kotlin/gg/flyte/pluginportal/common/types/VersionSelectionTest.kt
+++ b/common/src/test/kotlin/gg/flyte/pluginportal/common/types/VersionSelectionTest.kt
@@ -5,6 +5,7 @@ import java.time.Instant
 import java.util.Date
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class VersionSelectionTest {
     @Test
@@ -32,6 +33,42 @@ class VersionSelectionTest {
         val selected = versions.newestCompatibleVersion("release", listOf(ServerType.PAPER, ServerType.SPIGOT, ServerType.BUKKIT))
 
         assertEquals("1.9.0", selected?.versionNumber)
+    }
+
+    @Test
+    fun `defaults to a stable channel instead of a newer prerelease`() {
+        val versions = listOf(
+            version("2.0.0-alpha", "2026-06-02T00:00:00Z", ServerType.PAPER, channel = "alpha"),
+            version("1.9.0", "2026-06-01T00:00:00Z", ServerType.PAPER),
+        )
+
+        val selected = versions.newestCompatibleVersion(null, listOf(ServerType.PAPER))
+
+        assertEquals("1.9.0", selected?.versionNumber)
+    }
+
+    @Test
+    fun `honors an explicitly requested prerelease channel`() {
+        val versions = listOf(
+            version("2.0.0-beta", "2026-06-02T00:00:00Z", ServerType.PAPER, channel = "beta"),
+            version("1.9.0", "2026-06-01T00:00:00Z", ServerType.PAPER),
+        )
+
+        val selected = versions.newestCompatibleVersion("beta", listOf(ServerType.PAPER))
+
+        assertEquals("2.0.0-beta", selected?.versionNumber)
+    }
+
+    @Test
+    fun `does not silently cross to alpha when stable versions are incompatible`() {
+        val versions = listOf(
+            version("2.0.0-alpha", "2026-06-02T00:00:00Z", ServerType.PAPER, channel = "alpha", minecraftVersions = listOf("1.21.4")),
+            version("1.9.0", "2026-06-01T00:00:00Z", ServerType.PAPER, minecraftVersions = listOf("1.20.6")),
+        )
+
+        val selected = versions.newestCompatibleVersion(null, listOf(ServerType.PAPER), "1.21.4")
+
+        assertNull(selected)
     }
 
     @Test
@@ -113,6 +150,40 @@ class VersionSelectionTest {
         val selected = versions.newestCompatibleVersion("release", listOf(ServerType.PAPER, ServerType.SPIGOT, ServerType.BUKKIT), "1.21.4")
 
         assertEquals("1.9.0", selected?.versionNumber)
+    }
+
+    @Test
+    fun `does not install a version that explicitly targets another minecraft version`() {
+        val versions = listOf(
+            version("2.0.0", "2026-06-02T00:00:00Z", ServerType.PAPER, minecraftVersions = listOf("26.1")),
+            version("1.9.0", "2026-06-01T00:00:00Z", ServerType.PAPER, minecraftVersions = listOf("1.20.6")),
+        )
+
+        val selected = versions.newestCompatibleVersion("release", listOf(ServerType.PAPER), "1.21.4")
+
+        assertNull(selected)
+    }
+
+    @Test
+    fun `finds Advanced Portals Paper build beyond the cached first page`() {
+        val cachedVersions = listOf(
+            version("2.8.0-folia", "2026-05-27T21:30:47Z", ServerType.FOLIA, channel = "alpha", minecraftVersions = listOf("26.1.1")),
+            version("2.8.0-legacy-spigot", "2026-05-27T21:30:43Z", ServerType.BUKKIT, ServerType.SPIGOT, ServerType.PAPER, minecraftVersions = listOf("1.8.8", "1.12.2")),
+        )
+        val platform = platformEntry(cachedVersions)
+
+        val selected = platform.newestCompatibleVersionWithFallback(
+            null,
+            listOf(ServerType.PAPER, ServerType.SPIGOT, ServerType.BUKKIT),
+            "1.21.4",
+        ) {
+            cachedVersions + listOf(
+                version("2.8.0-spigot", "2026-05-27T21:30:37Z", ServerType.BUKKIT, ServerType.SPIGOT, ServerType.PAPER, minecraftVersions = listOf("1.21", "1.21.4")),
+                version("0.0.41", "2023-04-20T02:20:14Z", ServerType.PAPER, minecraftVersions = listOf("1.8.8", "1.12.2")),
+            )
+        }
+
+        assertEquals("2.8.0-spigot", selected?.versionNumber)
     }
 
     @Test

--- a/common/src/test/kotlin/gg/flyte/pluginportal/common/types/VersionSelectionTest.kt
+++ b/common/src/test/kotlin/gg/flyte/pluginportal/common/types/VersionSelectionTest.kt
@@ -8,6 +8,91 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class VersionSelectionTest {
+    private fun cachedAlpha() = version("3.0-alpha", "2026-06-03T00:00:00Z", ServerType.PAPER,
+        channel = "alpha", minecraftVersions = listOf("1.21.4"))
+
+    private fun installedPlugin() = LocalPlugin("entry", "project", "Example", "1.0",
+        gg.flyte.pluginportal.common.types.enums.MarketplacePlatform.MODRINTH, "installed-sha256", "installed-sha512", 0L)
+
+    @Test
+    fun `update selects later stable instead of cached newer alpha`() {
+        val alpha = cachedAlpha()
+        val selected = installedPlugin().targetUpdateVersion(platformEntry(listOf(alpha)), listOf(ServerType.PAPER), "1.21.4") {
+            listOf(alpha, version("2.0", "2026-06-02T00:00:00Z", ServerType.PAPER, minecraftVersions = listOf("1.21.4")))
+        }
+        assertEquals("2.0", selected?.versionNumber)
+    }
+
+    @Test
+    fun `update does not resurrect cached alpha when full stable is already installed`() {
+        val alpha = cachedAlpha()
+        val selected = installedPlugin().targetUpdateVersion(platformEntry(listOf(alpha)), listOf(ServerType.PAPER), "1.21.4") {
+            listOf(alpha, version("1.0", "2026-06-02T00:00:00Z", ServerType.PAPER, minecraftVersions = listOf("1.21.4")))
+        }
+        assertNull(selected)
+    }
+
+    @Test
+    fun `update with failed lookup does not fall back to implicit alpha`() {
+        assertNull(installedPlugin().targetUpdateVersion(platformEntry(listOf(cachedAlpha())), listOf(ServerType.PAPER), "1.21.4") { null })
+    }
+
+    @Test
+    fun `cached compatible alpha does not hide stable on later pages`() {
+        val alpha = cachedAlpha()
+        var fetched = false
+        val selected = platformEntry(listOf(alpha)).newestCompatibleVersionWithFallback(null, listOf(ServerType.PAPER), "1.21.4") {
+            fetched = true
+            listOf(alpha, version("2.0", "2026-06-02T00:00:00Z", ServerType.PAPER, minecraftVersions = listOf("1.21.4")))
+        }
+        assertEquals(true, fetched)
+        assertEquals("2.0", selected?.versionNumber)
+    }
+
+    @Test
+    fun `full lookup with incompatible stable does not resurrect cached alpha`() {
+        val alpha = cachedAlpha()
+        val selected = platformEntry(listOf(alpha)).newestCompatibleVersionWithFallback(null, listOf(ServerType.PAPER), "1.21.4") {
+            listOf(alpha, version("2.0", "2026-06-02T00:00:00Z", ServerType.PAPER, minecraftVersions = listOf("1.20.6")))
+        }
+        assertNull(selected)
+    }
+
+    @Test
+    fun `failed full lookup cannot establish that a project only has prereleases`() {
+        val selected = platformEntry(listOf(cachedAlpha())).newestCompatibleVersionWithFallback(null, listOf(ServerType.PAPER), "1.21.4") { null }
+        assertNull(selected)
+    }
+
+    @Test
+    fun `complete prerelease only project remains installable`() {
+        val alpha = cachedAlpha()
+        val selected = platformEntry(listOf(alpha)).newestCompatibleVersionWithFallback(null, listOf(ServerType.PAPER), "1.21.4") { listOf(alpha) }
+        assertEquals(alpha, selected)
+    }
+
+    @Test
+    fun `explicit alpha channel can use a compatible cached alpha`() {
+        val alpha = cachedAlpha()
+        val selected = platformEntry(listOf(alpha)).newestCompatibleVersionWithFallback("ALPHA", listOf(ServerType.PAPER), "1.21.4") {
+            error("An exact cached channel match should not need a full lookup")
+        }
+        assertEquals(alpha, selected)
+    }
+
+    @Test
+    fun `unordered versions and duplicate entries do not select oldest release`() {
+        val newest = version("2.0", "2026-06-02T00:00:00Z", ServerType.PAPER)
+        val old = version("1.0", "2026-06-01T00:00:00Z", ServerType.PAPER)
+        assertEquals(newest, listOf(old, newest, old).newestCompatibleVersion(null, listOf(ServerType.PAPER)))
+    }
+
+    @Test
+    fun `structured patch version does not imply compatibility with base version`() {
+        val versions = listOf(version("1.0", "2026-06-01T00:00:00Z", ServerType.PAPER, minecraftVersions = listOf("1.21.4")))
+        assertNull(versions.newestCompatibleVersion(null, listOf(ServerType.PAPER), "1.21"))
+    }
+
     @Test
     fun `chooses newest compatible version behind newer incompatible builds`() {
         val versions = listOf(
@@ -187,14 +272,14 @@ class VersionSelectionTest {
     }
 
     @Test
-    fun `treats minor minecraft versions as family compatibility`() {
+    fun `structured minor minecraft version does not imply later patch compatibility`() {
         val versions = listOf(
             version("1.0.0", "2026-06-01T00:00:00Z", ServerType.PAPER, minecraftVersions = listOf("1.21")),
         )
 
         val selected = versions.newestCompatibleVersion("release", listOf(ServerType.PAPER), "1.21.4")
 
-        assertEquals("1.0.0", selected?.versionNumber)
+        assertNull(selected)
     }
 
     @Test

--- a/plugin/src/main/kotlin/gg/flyte/pluginportal/plugin/commands/recognize/RecognizeAllSubCommand.kt
+++ b/plugin/src/main/kotlin/gg/flyte/pluginportal/plugin/commands/recognize/RecognizeAllSubCommand.kt
@@ -7,6 +7,7 @@ import gg.flyte.pluginportal.common.PlatformId
 import gg.flyte.pluginportal.common.chat.*
 import gg.flyte.pluginportal.common.commands.lamp.EnabledCommand
 import gg.flyte.pluginportal.common.commands.lamp.Features
+import gg.flyte.pluginportal.common.commands.lamp.ReleaseChannelSuggestionProvider
 import gg.flyte.pluginportal.common.managers.ExternalPluginManager
 import gg.flyte.pluginportal.common.managers.LocalPluginCache
 import gg.flyte.pluginportal.common.managers.MarketplacePluginCache
@@ -22,7 +23,10 @@ import net.kyori.adventure.audience.Audience
 import net.kyori.adventure.text.Component.text
 import net.kyori.adventure.text.format.NamedTextColor
 import revxrsal.commands.annotation.Command
+import revxrsal.commands.annotation.Flag
+import revxrsal.commands.annotation.Optional
 import revxrsal.commands.annotation.Subcommand
+import revxrsal.commands.annotation.SuggestWith
 import revxrsal.commands.bukkit.annotation.CommandPermission
 import java.io.File
 
@@ -42,7 +46,10 @@ class RecognizeAllSubCommand {
     @EnabledCommand(Features.RECOGNISE)
     @Subcommand("recognizeAll")
     @CommandPermission("pluginportal.manage.recognize")
-    fun recognizeAllCommand(audience: Audience) {
+    fun recognizeAllCommand(
+        audience: Audience,
+        @Optional @Flag("channel") @SuggestWith(ReleaseChannelSuggestionProvider::class) channel: String? = null,
+    ) {
         async {
             val externalHashes = ExternalPluginManager.managedHashes()
             val externalFileNames = ExternalPluginManager.managedFileNames()
@@ -98,7 +105,17 @@ class RecognizeAllSubCommand {
                         log("Could not find a compatible Bukkit/Paper version for ${plugin.name} from ${file.name}")
                         return@forEach noRecognize(file)
                     }
-                    val local = LocalPlugin(ppl.entryId, ppl.platformId, plugin.name, version, ppl.platform, sha256, sha512, System.currentTimeMillis())
+                    val local = LocalPlugin(
+                        ppl.entryId,
+                        ppl.platformId,
+                        plugin.name,
+                        version,
+                        ppl.platform,
+                        sha256,
+                        sha512,
+                        System.currentTimeMillis(),
+                        preferredChannel = channel?.takeIf { it.isNotBlank() },
+                    )
                     log("Found plugin ${ppl.platform} ${plugin.name} $version from ${file.name}")
                     LocalPluginCache.add(local)
                     recognizedPlugins.add(local)

--- a/plugin/src/main/kotlin/gg/flyte/pluginportal/plugin/commands/recognize/RecognizeSubCommand.kt
+++ b/plugin/src/main/kotlin/gg/flyte/pluginportal/plugin/commands/recognize/RecognizeSubCommand.kt
@@ -9,6 +9,7 @@ import gg.flyte.pluginportal.common.chat.sendInfo
 import gg.flyte.pluginportal.common.chat.sendSuccess
 import gg.flyte.pluginportal.common.commands.lamp.EnabledCommand
 import gg.flyte.pluginportal.common.commands.lamp.Features
+import gg.flyte.pluginportal.common.commands.lamp.ReleaseChannelSuggestionProvider
 import gg.flyte.pluginportal.common.managers.ExternalPluginManager
 import gg.flyte.pluginportal.common.managers.LocalPluginCache
 import gg.flyte.pluginportal.common.managers.MarketplacePluginCache
@@ -23,7 +24,9 @@ import gg.flyte.pluginportal.plugin.commands.lamp.RequiresAuth
 import gg.flyte.pluginportal.plugin.commands.lamp.SafeFileName
 import net.kyori.adventure.audience.Audience
 import revxrsal.commands.annotation.Command
+import revxrsal.commands.annotation.Flag
 import revxrsal.commands.annotation.Named
+import revxrsal.commands.annotation.Optional
 import revxrsal.commands.annotation.Subcommand
 import revxrsal.commands.annotation.SuggestWith
 import revxrsal.commands.bukkit.annotation.CommandPermission
@@ -40,7 +43,8 @@ class RecognizeSubCommand {
     @CommandPermission("pluginportal.manage.recognize")
     fun recognizeCommand(
         audience: Audience,
-        @Named("file") @SuggestWith(PluginJarFilesUnrecognisedSP::class) @SafeFileName pluginFileName: String
+        @Named("file") @SuggestWith(PluginJarFilesUnrecognisedSP::class) @SafeFileName pluginFileName: String,
+        @Optional @Flag("channel") @SuggestWith(ReleaseChannelSuggestionProvider::class) channel: String? = null,
     ) {
         async {
             logger.info("[ RECOGNITION ] - Attempting to recognize $pluginFileName")
@@ -123,6 +127,7 @@ class RecognizeSubCommand {
                     sha256,
                     sha512,
                     System.currentTimeMillis(),
+                    preferredChannel = channel?.takeIf { it.isNotBlank() },
                 )
             )
 


### PR DESCRIPTION
## Summary

- prefer `release` and `stable` builds when no channel is requested
- honor explicit beta, alpha, and custom channel requests
- refuse versions that explicitly target a different Minecraft version instead of falling back to one known to be incompatible
- allow `/pp recognize` and `/pp recognizeAll` to save a channel for future updates
- add an Advanced Portals regression shaped like the live paginated response

## Root cause and reproduction

The original oldest-version behavior had multiple causes. The full version fallback previously depended on the API's cached slice and response order. Current `master` already pages `/versions/platform/...` and orders compatible candidates by release date, but two unsafe selection rules remained:

1. A missing channel meant any channel, so a newer Modrinth prerelease could beat a stable release.
2. When every structured `mcVersions` value was incompatible, selection fell back to those known-incompatible versions.

The live Advanced Portals endpoint currently has 37 versions. With `limit=2`, page one contains `2.8.0-folia` and `2.8.0-legacy-spigot`; the Paper 1.21.4-compatible `2.8.0-spigot` build is on page two. The regression test preserves that shape and selects `2.8.0-spigot`, not legacy `0.0.41`.

## Verification

- `./gradlew test :plugin:compileKotlin`
- live read-only checks against Plugin Portal and Modrinth version endpoints for `axTqSWQA`
- `git diff --check`

Addresses #83.
Closes #100.

No release is included.
